### PR TITLE
Fix theme check in ezd_unlock_themes()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -36,7 +36,7 @@ function ezd_is_premium() {
  */
 function ezd_unlock_themes() {
 	$current_theme = get_template();
-	if ( $current_theme == 'Docy' || $current_theme == 'Docly' || ezd_is_premium() ) {
+	if ( $current_theme == 'docy' || $current_theme == 'docly' || ezd_is_premium() ) {
 		return true;
 	}
 }


### PR DESCRIPTION
`get_template()` returns the theme name in lowercase, but ezd_unlock_themes() was comparing the output to the strings "Docy" and "Docly" with an uppercase "D".

Since `==` is case sensitive in PHP, this caused the comparisons to **always** return `false` (usually incorrectly).