### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix unauthenticated access to private docs via shortcode

### DIFF
--- a/includes/Frontend/Shortcode.php
+++ b/includes/Frontend/Shortcode.php
@@ -60,13 +60,17 @@ class Shortcode {
         $args       = wp_parse_args( $args, $defaults );
         $arranged   = [];
 
+        // Sentinel: Prevent unauthorized access to private docs
+        $can_read_private = current_user_can( 'read_private_docs' ) || current_user_can( 'read_private_posts' );
+        $post_status      = $can_read_private ? [ 'publish', 'private' ] : [ 'publish' ];
+
         // Parent Docs Query Args
         $parent_args = [
             'post_type'     => 'docs',
             'post_parent'   => 0,
             'orderby'       => $args['parent_docs_order'],
             'order'         => strtoupper( $args['parent_docs_order_by'] ),
-            'post_status'   => [ 'publish', 'private' ],
+            'post_status'   => $post_status,
             'numberposts'   => $args['show_docs']
         ];
 
@@ -103,7 +107,7 @@ class Shortcode {
                 'post_parent__in' => $parent_ids,
                 'post_type'       => 'docs',
                 'numberposts'     => - 1,
-                'post_status'     => [ 'publish', 'private' ],
+                'post_status'     => $post_status,
                 'orderby'         => $args['parent_docs_order'],
                 'order'           => strtoupper( $args['child_docs_order'] ),
             ] );
@@ -137,6 +141,7 @@ class Shortcode {
             'show_topic'  => $args['show_topic'] ?? true,
             'topic_label' => $args['topic_label'] ?? esc_html__( 'Topics', 'eazydocs' ),
             'layout'      => $args['docs_layout'] ?? 'grid',
+            'post_status' => $post_status,
         ] );
     }
 }

--- a/templates/shortcode.php
+++ b/templates/shortcode.php
@@ -24,7 +24,7 @@ if ( $docs ) :
 					'post_type'   => 'docs',
 					'orderby'     => 'menu_order',
 					'order'       => 'asc',
-					'post_status' => array( 'publish', 'private' )
+					'post_status' => $post_status ?? array( 'publish' )
 				] );
 
 				global $post;


### PR DESCRIPTION
Fixed a security vulnerability where the `[eazydocs]` shortcode explicitly queried for `private` posts regardless of user capabilities.

Changes:
*   Modified `includes/Frontend/Shortcode.php` to dynamically set `$post_status` based on `read_private_docs` or `read_private_posts` capabilities.
*   Updated `templates/shortcode.php` to use the passed `$post_status` instead of a hardcoded array.

This ensures that unauthenticated users or users without permission cannot see private documentation titles or counts.

---
*PR created automatically by Jules for task [17284579029844709578](https://jules.google.com/task/17284579029844709578) started by @mdjwel*