### PR TITLE
🎨 Palette: Improve accessibility of doc filters and actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-22 - Context for Repeated Actions
 **Learning:** In EazyDocs admin templates (like `child-docs.php`), action buttons inside loops often use generic text ("Add Section") and sometimes duplicate IDs, confusing screen readers and breaking JS event delegation.
 **Action:** When refactoring repeated actions, replace duplicate IDs with classes, update JS delegates, and add `aria-label` including the parent item's name (e.g., "Add Section to [Doc Name]") to provide necessary context.
+
+## 2024-10-24 - State Management for Retrofitted Toggles
+**Learning:** When retrofitting semantic-less elements (like `<li>`) into buttons, purely adding attributes isn't enough; you must manually manage state (like `aria-pressed`).
+**Action:** Use a lightweight jQuery listener (e.g., `$(this).siblings().attr('aria-pressed', 'false')`) to toggle state without rewriting the underlying library (e.g., MixItUp) logic.

--- a/assets/js/admin/doc-builder.js
+++ b/assets/js/admin/doc-builder.js
@@ -430,6 +430,12 @@
 				.toggleClass('arrow-active', isExpanded);
 		});
 		
+		// Accessibility: Toggle aria-pressed for single-item-filter buttons
+		$('.single-item-filter .easydocs-btn').on('click', function() {
+			$(this).siblings().attr('aria-pressed', 'false');
+			$(this).attr('aria-pressed', 'true');
+		});
+
 		// Notifications filter buttons (Doc Builder page)
 		$('.easydocs-filters button').on('click', function(e){
 			e.preventDefault();

--- a/includes/Admin/template/child-docs.php
+++ b/includes/Admin/template/child-docs.php
@@ -20,28 +20,29 @@ if ( is_array( $depth_one_parents ) ) :
     foreach ( $depth_one_parents as $item ) :
         $ids++;
         $container++;
-        $active = $ids == 1 ? ' tab-active' : '';
+        $active       = $ids == 1 ? ' tab-active' : '';
+        $parent_title = get_the_title( $item );
         ?>
         <div class="easydocs-tab<?php echo esc_attr( $active ); ?>" id="tab-<?php echo esc_attr( $item ); ?>">
             <div class="easydocs-filter-container">
-                <ul class="single-item-filter">
-                    <li class="easydocs-btn easydocs-btn-black-light easydocs-btn-rounded easydocs-btn-sm is-active" data-filter="all">
+                <ul class="single-item-filter" role="group" aria-label="<?php esc_attr_e( 'Filter docs by status', 'eazydocs' ); ?>">
+                    <li class="easydocs-btn easydocs-btn-black-light easydocs-btn-rounded easydocs-btn-sm is-active" data-filter="all" role="button" tabindex="0" aria-pressed="true" onkeydown="if(event.key==='Enter'||event.key===' '){this.click();event.preventDefault();}">
                         <span class="dashicons dashicons-media-document"></span>
                         <?php esc_html_e('All articles', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-green-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".publish">
+                    <li class="easydocs-btn easydocs-btn-green-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".publish" role="button" tabindex="0" aria-pressed="false" onkeydown="if(event.key==='Enter'||event.key===' '){this.click();event.preventDefault();}">
                         <span class="dashicons dashicons-admin-site-alt3"></span>
                         <?php esc_html_e('Public', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-blue-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".private">
+                    <li class="easydocs-btn easydocs-btn-blue-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".private" role="button" tabindex="0" aria-pressed="false" onkeydown="if(event.key==='Enter'||event.key===' '){this.click();event.preventDefault();}">
                         <span class="dashicons dashicons-privacy"></span>
                         <?php esc_html_e('Private', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-orange-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".protected">
+                    <li class="easydocs-btn easydocs-btn-orange-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".protected" role="button" tabindex="0" aria-pressed="false" onkeydown="if(event.key==='Enter'||event.key===' '){this.click();event.preventDefault();}">
                         <span class="dashicons dashicons-lock"></span>
                         <?php esc_html_e('Protected', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-gray-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".draft">
+                    <li class="easydocs-btn easydocs-btn-gray-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".draft" role="button" tabindex="0" aria-pressed="false" onkeydown="if(event.key==='Enter'||event.key===' '){this.click();event.preventDefault();}">
                         <span class="dashicons dashicons-edit-page"></span>
                         <?php esc_html_e('Draft', 'eazydocs'); ?>
                     </li>


### PR DESCRIPTION
💡 **What:**
- Retrofitted the "All / Public / Private" filter tabs in the Child Docs list (Admin) to be accessible buttons.
- Added `role="button"`, `tabindex="0"`, and keyboard support (Enter/Space) to these list items.
- Added `aria-pressed` state management via a small JS snippet.
- Fixed a bug where the "Add Section" button had an empty or undefined document title in its `aria-label`.

🎯 **Why:**
- Previously, keyboard users could not navigate or activate the document status filters.
- Screen readers treated them as plain list items.
- The "Add Section" button announced "Add Section to " without the document name, confusing users.

♿ **Accessibility:**
- **Keyboard:** Filters are now focusable and activatable via keyboard.
- **Screen Readers:** Filters announce themselves as toggle buttons with correct state (`aria-pressed`).
- **Context:** Action buttons now correctly announce the target document name.

**Learning:**
- Retrofitting `<li>` filters requires manual state management (`aria-pressed`) since they aren't native form controls. A small JS sibling-toggle pattern handles this efficiently.

---
*PR created automatically by Jules for task [8249475829773663736](https://jules.google.com/task/8249475829773663736) started by @mdjwel*