### PR TITLE
🛡️ Sentinel: [HIGH] Fix information disclosure in ezd_list_pages

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -287,6 +287,10 @@ function ezd_reading_time() {
  * @return mixed|void
  */
 function ezd_list_pages( $args = '' ) {
+	// Sentinel: Prevent unauthorized access to private docs
+	$can_read_private = current_user_can( 'read_private_docs' ) || current_user_can( 'read_private_posts' );
+	$post_status      = $can_read_private ? [ 'publish', 'private' ] : [ 'publish' ];
+
 	$defaults = array(
 		'depth'        => 0,
 		'show_date'    => '',
@@ -301,7 +305,7 @@ function ezd_list_pages( $args = '' ) {
 		'link_after'   => '',
 		'item_spacing' => 'preserve',
 		'walker'       => '',
-		'post_status'  => ['publish', 'private']
+		'post_status'  => $post_status
 	);
 
 	$r = wp_parse_args( $args, $defaults );


### PR DESCRIPTION
Fixed a high-severity information disclosure vulnerability where private document titles were exposed to unauthorized users in navigation menus. 

The `ezd_list_pages` function in `includes/functions.php` previously hardcoded the `post_status` argument to `['publish', 'private']`, bypassing WordPress's implicit visibility checks in `get_pages`. This change introduces a dynamic check using `current_user_can('read_private_docs')` or `current_user_can('read_private_posts')` to only include 'private' status for authorized users. This aligns the list visibility with the single-document access control logic.

---
*PR created automatically by Jules for task [9782602833721575926](https://jules.google.com/task/9782602833721575926) started by @mdjwel*