### PR TITLE
🛡️ Sentinel: [HIGH] Fix information disclosure in private docs helper functions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The feedback form handler `eazydocs_feedback_email` allowed unlimited email submissions from unauthenticated users, leading to potential email spam and database flooding.
 **Learning:** Publicly accessible AJAX actions (`nopriv`) that trigger resource-intensive operations (sending emails, DB writes) must have rate limiting or CAPTCHA.
 **Prevention:** Implement IP-based transient rate limiting for all public-facing form handlers.
+
+## 2026-01-28 – Information Disclosure via Default Post Status
+**Vulnerability:** Helper functions `ezd_list_pages` and `ezd_get_posts` hardcoded `post_status` to include `private` posts, exposing private document titles to unauthorized users on the frontend.
+**Learning:** Functions wrapping `get_pages` or `WP_Query` should not default to including privileged statuses (`private`, `protected`) without checking user capabilities.
+**Prevention:** Dynamically construct `post_status` arrays based on `current_user_can('read_private_docs')`.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -287,6 +287,12 @@ function ezd_reading_time() {
  * @return mixed|void
  */
 function ezd_list_pages( $args = '' ) {
+	// Sentinel: Prevent unauthorized access to private docs
+	$post_status = [ 'publish' ];
+	if ( current_user_can( 'read_private_docs' ) || current_user_can( 'read_private_posts' ) ) {
+		$post_status[] = 'private';
+	}
+
 	$defaults = array(
 		'depth'        => 0,
 		'show_date'    => '',
@@ -301,7 +307,7 @@ function ezd_list_pages( $args = '' ) {
 		'link_after'   => '',
 		'item_spacing' => 'preserve',
 		'walker'       => '',
-		'post_status'  => ['publish', 'private']
+		'post_status'  => $post_status
 	);
 
 	$r = wp_parse_args( $args, $defaults );
@@ -1181,11 +1187,17 @@ function ezd_has_shortcode( $shortcodes = [] ) {
  * @return array
  */
 function ezd_get_posts( $post_type = 'docs' ) {
+	// Sentinel: Prevent unauthorized access to private docs
+	$post_status = [ 'publish' ];
+	if ( current_user_can( 'read_private_docs' ) || current_user_can( 'read_private_posts' ) ) {
+		$post_status[] = 'private';
+	}
+
 	$docs       = get_pages(
 		array(
 			'post_type'   => $post_type,
 			'numberposts' => - 1,
-			'post_status' => [ 'publish', 'private' ],
+			'post_status' => $post_status,
 			'parent'      => 0,
 		)
 	);


### PR DESCRIPTION
Secured `ezd_list_pages` and `ezd_get_posts` in `includes/functions.php` to prevent information disclosure of private documents to unauthorized users. Added Sentinel journal entry.

---
*PR created automatically by Jules for task [2294465215764402482](https://jules.google.com/task/2294465215764402482) started by @mdjwel*