### PR TITLE
🎨 Palette: Improved accessibility for document filters

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2024-05-22 - MixItUp Filters Accessibility
+**Learning:** MixItUp filters implemented as `<li>` elements are invisible to keyboard users and screen readers. They need explicit `role="button"`, `tabindex="0"`, and `aria-pressed` state management.
+**Action:** When using non-button elements for interactive filters, always add ARIA roles and keyboard event handlers (Enter/Space) to trigger the native click event.

--- a/assets/js/admin/doc-builder.js
+++ b/assets/js/admin/doc-builder.js
@@ -465,6 +465,25 @@
 			});
 		});
 		
+		/**
+		 * Accessibility: Keyboard support for doc filters
+		 * Allows Enter/Space to trigger click on filter items
+		 */
+		$('.single-item-filter .easydocs-btn').on('keydown', function(e) {
+			if (e.which === 13 || e.which === 32) {
+				e.preventDefault();
+				$(this).trigger('click');
+			}
+		});
+
+		/**
+		 * Accessibility: Update aria-pressed state on filter click
+		 */
+		$('.single-item-filter .easydocs-btn').on('click', function() {
+			$(this).siblings().attr('aria-pressed', 'false');
+			$(this).attr('aria-pressed', 'true');
+		});
+
 	});
 
 	// Glossary doc JS ==============

--- a/includes/Admin/template/child-docs.php
+++ b/includes/Admin/template/child-docs.php
@@ -25,23 +25,23 @@ if ( is_array( $depth_one_parents ) ) :
         <div class="easydocs-tab<?php echo esc_attr( $active ); ?>" id="tab-<?php echo esc_attr( $item ); ?>">
             <div class="easydocs-filter-container">
                 <ul class="single-item-filter">
-                    <li class="easydocs-btn easydocs-btn-black-light easydocs-btn-rounded easydocs-btn-sm is-active" data-filter="all">
+                    <li class="easydocs-btn easydocs-btn-black-light easydocs-btn-rounded easydocs-btn-sm is-active" data-filter="all" role="button" tabindex="0" aria-pressed="true">
                         <span class="dashicons dashicons-media-document"></span>
                         <?php esc_html_e('All articles', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-green-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".publish">
+                    <li class="easydocs-btn easydocs-btn-green-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".publish" role="button" tabindex="0" aria-pressed="false">
                         <span class="dashicons dashicons-admin-site-alt3"></span>
                         <?php esc_html_e('Public', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-blue-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".private">
+                    <li class="easydocs-btn easydocs-btn-blue-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".private" role="button" tabindex="0" aria-pressed="false">
                         <span class="dashicons dashicons-privacy"></span>
                         <?php esc_html_e('Private', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-orange-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".protected">
+                    <li class="easydocs-btn easydocs-btn-orange-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".protected" role="button" tabindex="0" aria-pressed="false">
                         <span class="dashicons dashicons-lock"></span>
                         <?php esc_html_e('Protected', 'eazydocs'); ?>
                     </li>
-                    <li class="easydocs-btn easydocs-btn-gray-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".draft">
+                    <li class="easydocs-btn easydocs-btn-gray-light easydocs-btn-rounded easydocs-btn-sm" data-filter=".draft" role="button" tabindex="0" aria-pressed="false">
                         <span class="dashicons dashicons-edit-page"></span>
                         <?php esc_html_e('Draft', 'eazydocs'); ?>
                     </li>


### PR DESCRIPTION
This PR addresses accessibility issues in the EazyDocs Doc Builder page where document filters were implemented as non-semantic `<li>` elements. 

**Changes:**
1.  **Semantic HTML/ARIA:** Added `role="button"`, `tabindex="0"`, and `aria-pressed` attributes to the filter list items in `includes/Admin/template/child-docs.php`.
2.  **Keyboard Interaction:** Added a `keydown` event listener in `assets/js/admin/doc-builder.js` to allow activating filters using Enter or Space keys.
3.  **State Management:** Added logic to update the `aria-pressed` state dynamically when filters are clicked or activated via keyboard.

**Why:**
Previously, keyboard users could not navigate or select filters, and screen reader users received no feedback about the filter's role or state. These changes ensure the interface complies with WCAG accessibility guidelines.


---
*PR created automatically by Jules for task [2737640173734340706](https://jules.google.com/task/2737640173734340706) started by @mdjwel*