### PR TITLE
📋 Warden: WPCS Cleanup for `includes/functions.php`

### DIFF
--- a/.warden/journal.md
+++ b/.warden/journal.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - WPCS Refactoring in Large Files
+**Learning:** When refactoring large files like `includes/functions.php` for WPCS compliance (array syntax, Yoda conditions), automated tools like `sed` or simple regex replacement are risky due to context sensitivity (e.g., matching parentheses, differentiating `is_array` from `array(`). Custom scripts must be extremely precise about token boundaries.
+**Action:** For large-scale refactoring, verify token boundaries explicitly (e.g., ensure `array` is not preceded by `_` or alphanumeric characters) and prefer manual batching or robust parsers over simple regex. Also, `replace_with_git_merge_diff` works best with unique context or small chunks.
+
+## 2024-05-23 - Strict Comparisons and Type Casting
+**Learning:** Functions like `ceil()` return float, and `get_var()` often returns string. When converting to strict comparisons (`===`), explicit casting (e.g., `(int)`) is crucial to avoid breaking logic that previously relied on loose comparison.
+**Action:** Always check the return type of the function being compared before switching to `===`. Use casting to enforce the expected type.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,7 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Get the value of a settings field.
  *
  * @param string $option  settings field name
- * @param string $section the section name this field belongs to
  * @param string $default default text if it's not found
  *
  * @return mixed
@@ -42,8 +41,8 @@ function ezd_meta_apply( $option_id, $default = '' ) {
 	$option_value = ezd_get_opt($option_id, $default);
 
 	// Check if meta value is an array and empty
-	$is_meta_arr_empty = is_array($meta_value) && empty(array_filter($meta_value));
-	if ( $meta_value == 'default' || $meta_value == '' || $meta_value == null || $is_meta_arr_empty ) {
+	$is_meta_arr_empty = is_array( $meta_value ) && empty( array_filter( $meta_value ) );
+	if ( 'default' === $meta_value || '' === $meta_value || null === $meta_value || $is_meta_arr_empty ) {
 		return $option_value;
 	}
 
@@ -82,7 +81,7 @@ function ezd_unlock_themes( ...$themes ) {
  */
 function ezd_is_footnotes_unlocked() {
 	$current_theme = strtolower( get_template() );
-	return ezd_is_promax() || in_array( $current_theme, array( 'docy', 'docly' ), true );
+	return ezd_is_promax() || in_array( $current_theme, [ 'docy', 'docly' ], true );
 }
 
 /**
@@ -104,7 +103,7 @@ function ezd_is_promax() {
  */
 function eazydocs_is_footnotes_unlocked() {
 	$current_theme = strtolower( get_template() );
-	return ezd_is_promax() || in_array( $current_theme, array( 'docy', 'docly' ), true );
+	return ezd_is_promax() || in_array( $current_theme, [ 'docy', 'docly' ], true );
 }
 
 /**
@@ -114,7 +113,7 @@ function eazydocs_is_footnotes_unlocked() {
  * @param int    $days        Number of days to check against
  * @return bool  True if plugin is installed for specified days, false otherwise
  */
-function ezd_is_plugin_installed_for_days( $days, $plugin_slug='eazydocs' ) {
+function ezd_is_plugin_installed_for_days( $days, $plugin_slug = 'eazydocs' ) {
 	// Get the installation timestamp of the plugin
 	$installed_time = get_option( $plugin_slug . '_installed' );
 
@@ -138,7 +137,7 @@ function ezd_is_plugin_installed_for_days( $days, $plugin_slug='eazydocs' ) {
  * @return string
  */
 function ezd_container() {
-	return ezd_get_opt('docs_page_width') == 'full-width' ? 'ezd-container-fluid' : 'ezd-container ezd-custom-container';
+	return 'full-width' === ezd_get_opt( 'docs_page_width' ) ? 'ezd-container-fluid' : 'ezd-container ezd-custom-container';
 }
 
 /**
@@ -158,7 +157,7 @@ function eazydocs_get_admin_template_part( $template ) {
  */
 function ezd_get_page_by_title( $title, $post_type = 'page' ) {
 	return get_posts(
-		array(
+		[
 			'post_type'              => $post_type,
 			'title'                  => $title,
 			'post_status'            => 'all',
@@ -167,7 +166,7 @@ function ezd_get_page_by_title( $title, $post_type = 'page' ) {
 			'update_post_meta_cache' => false,
 			'orderby'                => 'post_date ID',
 			'order'                  => 'ASC',
-		),
+		],
 	);
 }
 
@@ -180,7 +179,7 @@ function ezd_get_page_by_title( $title, $post_type = 'page' ) {
 function eazydocs_get_template_part( $template ) {
 	// Sanitize template name to prevent directory traversal attacks
 	// Remove any directory traversal sequences and null bytes
-	$template = str_replace( array( '..', "\0" ), '', $template );
+	$template = str_replace( [ '..', "\0" ], '', $template );
 	
 	// Get the slug
 	$template_slug = rtrim( $template, '.php' );
@@ -192,7 +191,7 @@ function eazydocs_get_template_part( $template ) {
 	}
 
 	// Check if a custom template exists in the theme folder, if not, load the plugin template file
-	if ( $theme_file = locate_template( array( 'eazydocs/' . $template ) ) ) {
+	if ( $theme_file = locate_template( [ 'eazydocs/' . $template ] ) ) {
 		$file = $theme_file;
 	} else {
 		//here path to '/single-paper.php'
@@ -226,7 +225,7 @@ function eazydocs_get_template( $template_name, $args = [] ) {
 	$ezd_obj = EazyDocs::init();
 
 	// Sanitize template name to prevent directory traversal attacks
-	$template_name = str_replace( array( '..', "\0" ), '', $template_name );
+	$template_name = str_replace( [ '..', "\0" ], '', $template_name );
 	
 	// Validate that template name only contains safe characters
 	if ( ! preg_match( '/^[a-zA-Z0-9_\-\/]+\.php$/', $template_name ) ) {
@@ -270,7 +269,7 @@ function ezd_reading_time() {
     $word_count  = str_word_count( wp_strip_all_tags( $content ) );
     $readingtime = ceil( $word_count / 200 );
 
-    if ( $readingtime == 1 ) {
+    if ( 1 === (int) $readingtime ) {
         $timer = esc_html__( " minute", 'eazydocs' );
     } else {
         $timer = esc_html__( " minutes", 'eazydocs' );
@@ -287,7 +286,7 @@ function ezd_reading_time() {
  * @return mixed|void
  */
 function ezd_list_pages( $args = '' ) {
-	$defaults = array(
+	$defaults = [
 		'depth'        => 0,
 		'show_date'    => '',
 		'date_format'  => get_option( 'date_format' ),
@@ -302,11 +301,11 @@ function ezd_list_pages( $args = '' ) {
 		'item_spacing' => 'preserve',
 		'walker'       => '',
 		'post_status'  => ['publish', 'private']
-	);
+	];
 
 	$r = wp_parse_args( $args, $defaults );
 
-	if ( ! in_array( $r['item_spacing'], array( 'preserve', 'discard' ), true ) ) {
+	if ( ! in_array( $r['item_spacing'], [ 'preserve', 'discard' ], true ) ) {
 		// invalid value, fall back to default.
 		$r['item_spacing'] = $defaults['item_spacing'];
 	}
@@ -318,7 +317,7 @@ function ezd_list_pages( $args = '' ) {
 	$r['exclude'] = preg_replace( '/[^0-9,]/', '', $r['exclude'] );
 
 	// Allow plugins to filter an array of excluded pages (but don't put a nullstring into the array)
-	$exclude_array = ( $r['exclude'] ) ? explode( ',', $r['exclude'] ) : array();
+	$exclude_array = ( $r['exclude'] ) ? explode( ',', $r['exclude'] ) : [];
 
 	/**
 	 * Filters the array of pages to exclude from the pages list.
@@ -436,7 +435,7 @@ if ( ! function_exists( 'eazydocs_breadcrumbs' ) ) {
 			$html .= $args['delimiter'];
 		}
 
-		if ( 'docs' == $post->post_type && $post->post_parent ) {
+		if ( 'docs' === $post->post_type && $post->post_parent ) {
 			$parent_id   = $post->post_parent;
 			$breadcrumbs = [];
 
@@ -495,7 +494,7 @@ if ( ! function_exists( 'eazydocs_search_breadcrumbs' ) ) {
 			$html .= $args['delimiter'];
 		}
 
-		if ( 'docs' == $post->post_type && $post->post_parent ) {
+		if ( 'docs' === $post->post_type && $post->post_parent ) {
 			$parent_id   = $post->post_parent;
 			$breadcrumbs = [];
 
@@ -541,8 +540,8 @@ if ( ! function_exists( 'docs_root_title' ) ) {
 		$breadcrumb_position = 1;
 
 		$is_parents = get_ancestors( $post->ID, 'docs' );
-		$is_parent  = $is_parents[0];
-		if ( $is_parent == 0 ) {
+		$is_parent  = $is_parents[0] ?? 0;
+		if ( 0 === $is_parent ) {
 			$parent_id = $post->ID;
 		} else {
 			$parent_id = $is_parent;
@@ -555,7 +554,7 @@ if ( ! function_exists( 'docs_root_title' ) ) {
 		$docs_page_title = ezd_get_opt( 'docs-page-title' );
 		$docs_page_title = ! empty( $docs_page_title ) ? esc_html( $docs_page_title ) : esc_html__( 'Docs', 'eazydocs' );
 
-		if ( 'docs' == $post->post_type && $post->post_parent ) {
+		if ( 'docs' === $post->post_type && $post->post_parent ) {
 			$parent_id   = $post->post_parent;
 			$breadcrumbs = [];
 
@@ -624,7 +623,7 @@ function eazydocs_get_global_post_field( $field = 'ID', $context = 'edit' ) {
 function eazydocs_has_shortcode( $text = '' ) {
 	// Default return value
 	$retval = false;
-	$found  = array();
+	$found  = [];
 
 	// Fallback to global post_content
 	if ( empty( $text ) && is_singular() ) {
@@ -635,7 +634,7 @@ function eazydocs_has_shortcode( $text = '' ) {
 	if ( ! empty( $text ) && ( false !== strpos( $text, '[eazydocs' ) ) ) {
 
 		// Get possible shortcodes
-		$codes = array( 'eazydocs', 'eazydocs_tab' );
+		$codes = [ 'eazydocs', 'eazydocs_tab' ];
 
 		// Loop through codes
 		foreach ( $codes as $code ) {
@@ -707,11 +706,11 @@ add_action( 'admin_footer', function () {
  * @return string
  */
 function eazydocs_pro_doc_list() {
-	$args = array(
+	$args = [
 		'posts_per_page' => - 1,
-		'post_type'      => array( 'docs' ),
+		'post_type'      => [ 'docs' ],
 		'post_parent'    => 0
-	);
+	];
 	$docs      		= get_posts( $args );
 	$doc_item_count = 0;
 	$doc_items 		= '<option value="">Select a doc</option>';
@@ -744,7 +743,7 @@ function eazydocs_one_page( $doc_id ) {
 		'name'        => $post_name,
 	] );
 
-	if ( $post_status != 'draft' ) :
+	if ( 'draft' !== $post_status ) :
 		if ( count( $one_page_docs ) < 1 ) :
 
 			// Generate a secure URL with nonce
@@ -806,15 +805,15 @@ function ezd_hex2rgba( $color, $opacity = false ) {
 	}
 
 	//Sanitize $color if "#" is provided
-	if ( $color[0] == '#' ) {
+	if ( '#' === $color[0] ) {
 		$color = substr( $color, 1 );
 	}
 
 	//Check if color has 6 or 3 characters and get values
-	if ( strlen( $color ) == 6 ) {
-		$hex = array( $color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5] );
-	} elseif ( strlen( $color ) == 3 ) {
-		$hex = array( $color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2] );
+	if ( 6 === strlen( $color ) ) {
+		$hex = [ $color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5] ];
+	} elseif ( 3 === strlen( $color ) ) {
+		$hex = [ $color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2] ];
 	} else {
 		return $default;
 	}
@@ -971,7 +970,7 @@ function ezd_onepage_docs() {
 
 add_action( 'save_post', function ( $post_id ) {
 	// Doc Options
-	if ( 'onepage-docs' != get_post_type( $post_id ) ) {
+	if ( 'onepage-docs' !== get_post_type( $post_id ) ) {
 		return;
 	}
 
@@ -1002,10 +1001,10 @@ add_image_size( 'ezd_searrch_thumb16x16', '16', '16', true );
 add_image_size( 'ezd_searrch_thumb50x50', '50', '50', true );
 
 // Doc password form
-function ezd_password_form($output, $post = 0) {
+function ezd_password_form( $output, $post = 0 ) {
 
     // Check if post is set and is the desired custom post type
-    if ( is_null( $post ) || (get_post_type( $post ) !== 'docs')) {
+    if ( is_null( $post ) || ( 'docs' !== get_post_type( $post ) ) ) {
         // If it's not the correct post type, return the original output
         return $output;
     }
@@ -1014,7 +1013,7 @@ function ezd_password_form($output, $post = 0) {
 	$protected_form_title    = ezd_is_premium() ? ezd_get_opt( 'protected_form_title', esc_html__( 'Enter Password & Read this Doc', 'eazydocs' ) ) : esc_html__( 'Enter Password & Read this Doc', 'eazydocs' );
 	$protected_form_subtitle = ezd_is_premium() ? ezd_get_opt( 'protected_form_subtitle', esc_html__( 'This content is password protected. To view it please enter your password below:', 'eazydocs' ) ) : esc_html__( 'This content is password protected. To view it please enter your password below:', 'eazydocs' );
 
-	if ( ! empty( $protected_form_switcher == 'eazydocs-form' ) ) :
+	if ( 'eazydocs-form' === $protected_form_switcher ) :
 		ob_start();
 		?>
 		<div class="card ezd-password-wrap">
@@ -1182,12 +1181,12 @@ function ezd_has_shortcode( $shortcodes = [] ) {
  */
 function ezd_get_posts( $post_type = 'docs' ) {
 	$docs       = get_pages(
-		array(
+		[
 			'post_type'   => $post_type,
 			'numberposts' => - 1,
 			'post_status' => [ 'publish', 'private' ],
 			'parent'      => 0,
-		)
+		]
 	);
 	$docs_array = [];
 	if ( $docs ) {
@@ -1243,7 +1242,7 @@ function ezd_el_title_tags() {
  */
 function ezd_el_image( $settings_key = '', $alt = '', $class = '', $atts = [] ) {
 	if ( ! empty( $settings_key['id'] ) ) {
-		echo wp_get_attachment_image( $settings_key['id'], 'full', '', array( 'class' => $class ) );
+		echo wp_get_attachment_image( $settings_key['id'], 'full', '', [ 'class' => $class ] );
 	} elseif ( ! empty( $settings_key['url'] ) && empty( $settings_key['id'] ) ) {
 		$class = ! empty( $class ) ? "class='$class'" : '';
 		$attss = '';
@@ -1277,7 +1276,7 @@ function eaz_get_nestable_parent_id( $page_id ) {
 	// @codingStandardsIgnoreLine WordPress.DB.DirectDatabaseQuery.DirectQuery
 	$parent = $wpdb->get_var( $query );
 
-	if ( $parent == 0 ) {
+	if ( 0 === (int) $parent ) {
 		return $page_id;
 	} else {
 		return eaz_get_nestable_parent_id( $parent );
@@ -1292,12 +1291,12 @@ function eaz_get_nestable_parent_id( $page_id ) {
  * @return array[]|int[]|WP_Post[]
  */
 function eaz_get_nestable_children( $post_id ) {
-	return get_children( array(
+	return get_children( [
 		'post_parent' => $post_id,
 		'post_type'   => 'docs',
 		'orderby'     => 'menu_order',
 		'order'       => 'ASC',
-	) );
+	] );
 }
 
 /**
@@ -1308,7 +1307,7 @@ function eaz_get_nestable_children( $post_id ) {
  * @return string all shortcodes from content
  */
 function ezd_all_shortcodes( $content ) {
-	$return = array();
+	$return = [];
 	preg_match_all( '/' . get_shortcode_regex() . '/', $content, $shortcodes, PREG_SET_ORDER );
 	if ( ! empty( $shortcodes ) ) {
 		foreach ( $shortcodes as $shortcode ) {
@@ -1333,7 +1332,7 @@ function ezd_kses_allowed_docs_nav_html() {
 	$allowed = wp_kses_allowed_html( 'post' );
 
 	// Allow inline SVG icons used by docs navigation.
-	$allowed['svg'] = array(
+	$allowed['svg'] = [
 		'class'            => true,
 		'xmlns'            => true,
 		'width'            => true,
@@ -1348,16 +1347,16 @@ function ezd_kses_allowed_docs_nav_html() {
 		'role'             => true,
 		'aria-hidden'      => true,
 		'focusable'        => true,
-	);
-	$allowed['path'] = array(
+	];
+	$allowed['path'] = [
 		'd'               => true,
 		'fill'            => true,
 		'stroke'          => true,
 		'stroke-width'    => true,
 		'stroke-linecap'  => true,
 		'stroke-linejoin' => true,
-	);
-	$allowed['rect'] = array(
+	];
+	$allowed['rect'] = [
 		'x'      => true,
 		'y'      => true,
 		'width'  => true,
@@ -1366,18 +1365,18 @@ function ezd_kses_allowed_docs_nav_html() {
 		'ry'     => true,
 		'fill'   => true,
 		'stroke' => true,
-	);
-	$allowed['circle'] = array(
+	];
+	$allowed['circle'] = [
 		'cx'    => true,
 		'cy'    => true,
 		'r'     => true,
 		'fill'  => true,
 		'stroke'=> true,
-	);
-	$allowed['g'] = array(
+	];
+	$allowed['g'] = [
 		'fill'   => true,
 		'stroke' => true,
-	);
+	];
 
 	return apply_filters( 'ezd_kses_allowed_docs_nav_html', $allowed );
 }
@@ -1390,7 +1389,11 @@ add_filter( 'body_class', function( $classes ) {
 });
 
 
-// check if block theme activated
+/**
+ * Check if block theme activated and load header.
+ *
+ * @return void
+ */
 function ezd_header_with_block_theme() {
 	if ( function_exists( 'block_header_area' ) ) {
 		// Include your template part
@@ -1410,7 +1413,7 @@ function ezd_header_with_block_theme() {
  * Footer with block theme
  * @return void
  */
-function ezd_footer_with_block_theme(){
+function ezd_footer_with_block_theme() {
 	if ( function_exists( 'block_footer_area' ) ) {
 		block_template_part('footer');
 		?>
@@ -1428,13 +1431,13 @@ function ezd_footer_with_block_theme(){
  * @return array
  */
 function ezd_get_elementor_templates() {
-	$elementor_templates = get_posts( array(
+	$elementor_templates = get_posts( [
 		'post_type' 		=> 'elementor_library',
 		'posts_per_page' 	=> -1,
 		'status' 			=> 'publish'
-	) );
+	] );
 
-	$elementor_templates_array = array();
+	$elementor_templates_array = [];
 	if ( ! empty( $elementor_templates ) ) {
 		foreach ( $elementor_templates as $elementor_template ) {
 			$elementor_templates_array[$elementor_template->ID] = $elementor_template->post_title;
@@ -1447,24 +1450,28 @@ function ezd_get_elementor_templates() {
  * Get all templates from Elementor
  * @return array
  */
-function ezd_single_banner($classes) {
+function ezd_single_banner( $classes ) {
 	$current_theme = get_template();
-	if ( is_single() && get_post_type() == 'docs' && ! empty( ezd_get_opt('single_doc_layout') == 'el-template' ) &&  ! empty( ezd_get_opt('single_layout_id') ) && $current_theme == 'docly' ) {
+	if ( is_single() && 'docs' === get_post_type() && 'el-template' === ezd_get_opt( 'single_doc_layout' ) && ! empty( ezd_get_opt( 'single_layout_id' ) ) && 'docly' === $current_theme ) {
 		$classes[] = 'disable-docly-header';
-    }
-    return $classes;
+	}
+	return $classes;
 }
 add_filter('body_class', 'ezd_single_banner');
 
 /**
- * Editor & Administrator access
+ * Editor & Administrator access.
+ *
+ * @param int|string $post_id Post ID.
+ * @param string     $action  Action name.
+ * @return bool
  */
 function ezd_is_admin_or_editor( $post_id = '', $action = '' ) {
 	if ( empty( $post_id ) ) {
 		return current_user_can( 'edit_docs' ) || current_user_can( 'manage_options' );
 	}
 
-	if ( $action == 'delete' ) {
+	if ( 'delete' === $action ) {
 		return current_user_can( 'delete_doc', $post_id ) || current_user_can( 'manage_options' );
 	}
 
@@ -1481,8 +1488,8 @@ function ezd_is_admin_or_editor( $post_id = '', $action = '' ) {
  */
 function ezd_internal_doc_security( $doc_id = 0 ) {
 	// Private doc restriction
-	if ( get_post_status( $doc_id ) == 'private' ) {
-		
+	if ( 'private' === get_post_status( $doc_id ) ) {
+
 		// Try new settings first
 		$access_type = ezd_get_opt( 'private_doc_access_type', '' );
 		
@@ -1495,9 +1502,9 @@ function ezd_internal_doc_security( $doc_id = 0 ) {
 				}
 			} else {
 				// Specific roles only
-				$allowed_roles = ezd_get_opt( 'private_doc_allowed_roles', array( 'administrator', 'editor' ) );
+				$allowed_roles = ezd_get_opt( 'private_doc_allowed_roles', [ 'administrator', 'editor' ] );
 				if ( ! is_array( $allowed_roles ) ) {
-					$allowed_roles = array( $allowed_roles );
+					$allowed_roles = [ $allowed_roles ];
 				}
 				
 				// Current user roles
@@ -1529,7 +1536,7 @@ function ezd_internal_doc_security( $doc_id = 0 ) {
 				$current_roles   = (array) $current_user->roles;
 
 				// All selected roles
-				$private_doc_roles = $user_group['private_doc_roles'] ?? array();
+				$private_doc_roles = $user_group['private_doc_roles'] ?? [];
 				$matching_roles    = array_intersect( $current_roles, $private_doc_roles );
 
 				if ( ! empty( $matching_roles ) || current_user_can( 'manage_options' ) ) {
@@ -1552,7 +1559,7 @@ function ezd_internal_doc_security( $doc_id = 0 ) {
 /**
  * Delete doc secured by user role security
 */
-function ezd_perform_edit_delete_actions( $action = 'delete', $docID = 0 ){
+function ezd_perform_edit_delete_actions( $action = 'delete', $docID = 0 ) {
 	// Get the current user ID
 	$current_user_id = get_current_user_id();
 	$inline_styles   = "margin: 50px auto; background: #f5f3f3;padding: 10px 80px;	width: max-content;	font-size: 16px;font-weight: 500;font-family: system-ui;border-radius: 3px;	color: #363636;";
@@ -1600,7 +1607,7 @@ function ezd_get_doc_parent_id( $doc_id = 0 ) {
  */
  function ezd_get_conditional_items() {
 	if ( ! ezd_is_promax() ) {
-		return array();
+		return [];
 	}
 	$conditional_items 	= ezd_get_opt('condition_options');
 	$conditional_array 	= [];
@@ -1640,9 +1647,9 @@ if ( ! function_exists( 'ezd_slug_validate' ) ) {
  *
  * @param int $post_id The ID of the post to retrieve the "reference" shortcodes from
  */
-function ezd_get_footnotes_in_content($post_id) {
+function ezd_get_footnotes_in_content( $post_id ) {
     // Retrieve the post by its ID
-    $post = get_post($post_id);
+    $post = get_post( $post_id );
 
     // Check if the post exists
     if (!$post) {
@@ -1706,13 +1713,13 @@ add_filter('the_content', 'ezd_footnote_number_attribute');
  * This function dynamically updates footnote content in the single 'docs'
  * It targets <span> elements with specific attributes and checks for <i> tags to add an onclick event.
  */
-function ezd_update_footnotes_content($content) {
+function ezd_update_footnotes_content( $content ) {
     // Apply only to single 'docs' post type
     if (is_singular('docs')) {
         // Regular expression to match the required span tag
         $pattern = '/<span id="serial-id-(\d+)" class="ezd-footnotes-link-item" data-bs-original-title="(.*?)">.*?<i(.*?)>(.*?)<\/i>.*?<span class="ezd-footnote-content">(.*?)<\/span><\/span>/s';
 
-        $content = preg_replace_callback($pattern, function ($matches) {
+        $content = preg_replace_callback($pattern, function ( $matches ) {
             $id 				= $matches[1];
             $original_title 	= $matches[2];
             $i_attributes 		= $matches[3];
@@ -1756,12 +1763,12 @@ function customizer_visibility_callback() {
         $doc_id   = ezd_get_opt( 'docs-slug' );
         $doc_page = get_post_field( 'post_name', $doc_id );
 
-        $args = array(
+        $args = [
             'post_type'      => 'docs',
             'posts_per_page' => -1,
             'orderby'        => 'menu_order',
             'order'          => 'asc'
-        );
+        ];
 
         $recent_posts = get_posts( $args );
         $post_url     = '';
@@ -1875,12 +1882,12 @@ function ezd_read_private_docs_cap_to_user() {
         // Using new settings
         if ( $access_type === 'all_users' ) {
             // All logged-in users can access
-			$get_users_role = function_exists( 'eazydocs_user_role_names' ) ? array_values( array_keys( eazydocs_user_role_names() ) ) : array();
+			$get_users_role = function_exists( 'eazydocs_user_role_names' ) ? array_values( array_keys( eazydocs_user_role_names() ) ) : [];
         } else {
             // Specific roles only
-            $get_users_role = ezd_get_opt( 'private_doc_allowed_roles', array( 'administrator', 'editor' ) );
+            $get_users_role = ezd_get_opt( 'private_doc_allowed_roles', [ 'administrator', 'editor' ] );
             if ( ! is_array( $get_users_role ) ) {
-                $get_users_role = array( $get_users_role );
+                $get_users_role = [ $get_users_role ];
             }
         }
     } else {
@@ -1889,11 +1896,11 @@ function ezd_read_private_docs_cap_to_user() {
         $is_all_user = $user_group['private_doc_all_user'] ?? 0;
 
         if ( $is_all_user === '1' || $is_all_user === 1 || $is_all_user === true ) {
-			$get_users_role = function_exists( 'eazydocs_user_role_names' ) ? array_values( array_keys( eazydocs_user_role_names() ) ) : array();
+			$get_users_role = function_exists( 'eazydocs_user_role_names' ) ? array_values( array_keys( eazydocs_user_role_names() ) ) : [];
         } else {
-            $get_users_role = $user_group['private_doc_roles'] ?? array();
+            $get_users_role = $user_group['private_doc_roles'] ?? [];
             if ( ! is_array( $get_users_role ) ) {
-                $get_users_role = array( $get_users_role );
+                $get_users_role = [ $get_users_role ];
             }
         }
     }
@@ -1921,20 +1928,20 @@ add_action( 'init', 'ezd_read_private_docs_cap_to_user' );
 function ezd_docs_cap_to_user() {
 	$collaboration_roles = ezd_get_opt( 'ezd_add_editable_roles' );
 	$write_access_roles  = ezd_get_opt( 'docs-write-access' );
-	$default_roles       = array( 'administrator', 'editor', 'author' );
+	$default_roles       = [ 'administrator', 'editor', 'author' ];
 
 	if ( ! is_array( $collaboration_roles ) ) {
-		$collaboration_roles = array_filter( array( $collaboration_roles ) );
+		$collaboration_roles = array_filter( [ $collaboration_roles ] );
 	}
 
 	if ( ! is_array( $write_access_roles ) ) {
-		$write_access_roles = array_filter( array( $write_access_roles ) );
+		$write_access_roles = array_filter( [ $write_access_roles ] );
 	}
 
 	$active_roles = array_unique( array_merge( $collaboration_roles, $write_access_roles ) );
 	$active_roles = ! empty( $active_roles ) ? $active_roles : $default_roles;
 
-	$author_caps = array(
+	$author_caps = [
 		'edit_doc',
 		'edit_docs',
 		'publish_docs',
@@ -1942,15 +1949,15 @@ function ezd_docs_cap_to_user() {
 		'delete_docs',
 		'edit_published_docs',
 		'delete_published_docs'
-	);
+	];
 
-	$manager_caps = array(
+	$manager_caps = [
 		'edit_others_docs',
 		'delete_others_docs',
 		'edit_private_docs',
 		'read_private_docs',
 		'delete_private_docs',
-	);
+	];
 
 	// Get all roles
 	global $wp_roles;
@@ -2072,10 +2079,10 @@ function ezd_docs_slug() {
 
 	$docs_url	  = ezd_get_opt( 'docs-url-structure', 'custom-slug' );
 	$permalink    = get_option( 'permalink_structure' );
-    $custom_slug  = ezd_get_opt( 'docs-type-slug' );
-    $safe_slug 	  = preg_replace( '/[^a-zA-Z0-9-_]/', '-', $custom_slug );
-	
-	if ( $docs_url == 'custom-slug' || $permalink === '' || $permalink === '/archives/%post_id%' ) {
+	$custom_slug  = ezd_get_opt( 'docs-type-slug' );
+	$safe_slug    = preg_replace( '/[^a-zA-Z0-9-_]/', '-', $custom_slug );
+
+	if ( 'custom-slug' === $docs_url || '' === $permalink || '/archives/%post_id%' === $permalink ) {
 		return $safe_slug ?: 'docs';
 	}
 
@@ -2160,7 +2167,7 @@ function ezd_prev_next_docs( $current_post_id ) {
 	$post_type = get_post_type( $current_post_id );
 
 	// Step 1: Get all top-level docs
-	$top_level_docs = get_posts( array(
+	$top_level_docs = get_posts( [
 		'post_type'   => $post_type,
 		'post_status' => 'publish',
 		'post_parent' => 0,
@@ -2168,7 +2175,7 @@ function ezd_prev_next_docs( $current_post_id ) {
 		'order'       => 'ASC',
 		'fields'      => 'ids',
 		'numberposts' => -1,
-	) );
+	] );
 
 	// Step 2: Recursively build a flat ordered list
 	$ordered_ids = [];
@@ -2192,7 +2199,7 @@ function ezd_prev_next_docs( $current_post_id ) {
 function ezd_docs_build_tree_flat( $post_id, &$list ) {
 	$list[] = $post_id;
 
-	$children = get_posts( array(
+	$children = get_posts( [
 		'post_type'   => get_post_type( $post_id ),
 		'post_status' => 'publish',
 		'post_parent' => $post_id,
@@ -2200,7 +2207,7 @@ function ezd_docs_build_tree_flat( $post_id, &$list ) {
 		'order'       => 'ASC',
 		'fields'      => 'ids',
 		'numberposts' => -1,
-	) );
+	] );
 
 	foreach ( $children as $child_id ) {
 		ezd_docs_build_tree_flat( $child_id, $list );
@@ -2421,7 +2428,7 @@ function ezd_import_sample_data() {
 
 	// Check user capabilities.
 	if ( ! current_user_can( 'manage_options' ) ) {
-		wp_send_json_error( array( 'message' => esc_html__( 'You do not have permission to import data.', 'eazydocs' ) ) );
+		wp_send_json_error( [ 'message' => esc_html__( 'You do not have permission to import data.', 'eazydocs' ) ] );
 	}
 
 	// Path to the sample data XML file.
@@ -2429,7 +2436,7 @@ function ezd_import_sample_data() {
 
 	// Check if the file exists.
 	if ( ! file_exists( $sample_data_file ) ) {
-		wp_send_json_error( array( 'message' => esc_html__( 'Sample data file not found.', 'eazydocs' ) ) );
+		wp_send_json_error( [ 'message' => esc_html__( 'Sample data file not found.', 'eazydocs' ) ] );
 	}
 
 	// Include WordPress importer files.
@@ -2451,9 +2458,9 @@ function ezd_import_sample_data() {
 			// Importer not available, use manual import.
 			$result = ezd_manual_import_sample_data( $sample_data_file );
 			if ( is_wp_error( $result ) ) {
-				wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+				wp_send_json_error( [ 'message' => $result->get_error_message() ] );
 			}
-			wp_send_json_success( array( 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ) );
+			wp_send_json_success( [ 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ] );
 		}
 	}
 
@@ -2466,14 +2473,14 @@ function ezd_import_sample_data() {
 		$wp_import->import( $sample_data_file );
 		ob_end_clean();
 
-		wp_send_json_success( array( 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ) );
+		wp_send_json_success( [ 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ] );
 	} else {
 		// Fallback to manual import.
 		$result = ezd_manual_import_sample_data( $sample_data_file );
 		if ( is_wp_error( $result ) ) {
-			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+			wp_send_json_error( [ 'message' => $result->get_error_message() ] );
 		}
-		wp_send_json_success( array( 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ) );
+		wp_send_json_success( [ 'message' => esc_html__( 'Sample data imported successfully!', 'eazydocs' ) ] );
 	}
 }
 
@@ -2505,7 +2512,7 @@ function ezd_manual_import_sample_data( $file ) {
 	$content_ns = isset( $namespaces['content'] ) ? $namespaces['content'] : '';
 
 	// Track old ID to new ID mapping for parent relationships.
-	$id_mapping = array();
+	$id_mapping = [];
 
 	// First pass: Create all docs without parent relationships.
 	foreach ( $xml->channel->item as $item ) {
@@ -2521,12 +2528,12 @@ function ezd_manual_import_sample_data( $file ) {
 
 		// Check if a doc with the same title already exists.
 		$existing = get_posts(
-			array(
+			[
 				'post_type'   => 'docs',
 				'title'       => $title,
 				'post_status' => 'any',
 				'numberposts' => 1,
-			)
+			]
 		);
 
 		if ( ! empty( $existing ) ) {
@@ -2539,14 +2546,14 @@ function ezd_manual_import_sample_data( $file ) {
 		$post_content = isset( $content_data->encoded ) ? (string) $content_data->encoded : '';
 
 		// Create the doc post.
-		$post_data = array(
+		$post_data = [
 			'post_title'   => sanitize_text_field( $title ),
 			'post_content' => wp_kses_post( $post_content ),
 			'post_status'  => ( (string) $wp_data->status === 'private' ) ? 'publish' : sanitize_text_field( (string) $wp_data->status ),
 			'post_type'    => 'docs',
 			'menu_order'   => (int) $wp_data->menu_order,
 			'post_parent'  => 0, // Will be updated in second pass.
-		);
+		];
 
 		$new_id = wp_insert_post( $post_data );
 
@@ -2567,10 +2574,10 @@ function ezd_manual_import_sample_data( $file ) {
 
 		if ( ! empty( $temp_parent ) && isset( $id_mapping[ $temp_parent ] ) ) {
 			wp_update_post(
-				array(
+				[
 					'ID'          => $new_id,
 					'post_parent' => $id_mapping[ $temp_parent ],
-				)
+				]
 			);
 		}
 


### PR DESCRIPTION
## 📋 Warden: WPCS Cleanup for `includes/functions.php`

### 💡 What Changed
- **Standardized Array Syntax**: Converted all instances of `array()` to short syntax `[]` in `includes/functions.php` for consistency with modern PHP and other plugin files.
- **Enforced Yoda Conditions**: Updated conditional checks to place constants/literals on the left side (e.g., `'value' === $var`).
- **Strict Comparisons**: Switched loose comparisons (`==`, `!=`) to strict comparisons (`===`, `!==`) where data types are known or castable (e.g., casting `get_var` results or `ceil` results to `int` before comparing).
- **Spacing & Formatting**: Fixed spacing inside parentheses and closure declarations to align with WPCS.
- **Improved Docblocks**: Added or fixed missing docblocks for functions like `ezd_header_with_block_theme`, `ezd_is_admin_or_editor`, and fixed parameter documentation in `ezd_get_opt`.

### 🎯 Why
- **Consistency**: The codebase mixed `array()` and `[]` syntax. Standardizing improves readability and consistency.
- **WPCS Compliance**: WordPress Coding Standards require Yoda conditions and encourage strict comparisons to prevent bugs.
- **Code Quality**: Proper spacing and documentation improve maintainability.

### 📊 Impact
- **Code quality**: High. `includes/functions.php` is now cleaner and more standard-compliant.
- **Behavior**: No functional changes. Logic equivalence was maintained (e.g., by adding `(int)` casting where strict comparison required it).

### 🧪 How Tested
- [x] Syntax Check: `php -l includes/functions.php` passed.
- [x] Manual Verification: Verified that `array()` constructs are gone but function calls like `is_array()` remain intact. Checked logic for strict comparisons on `reading_time` (float -> int), `parent_id` (string/int -> int), and hex color lengths.

### 🧩 Compatibility Notes
- PHP: 7.4+ (Plugin requirement).
- WordPress: Standard APIs used.

### 📋 Checklist
- [x] No breaking changes to public hooks/filters
- [x] No functional/behavior changes (style/quality only)
- [x] Changes scoped to stated theme only


---
*PR created automatically by Jules for task [2625480598198926612](https://jules.google.com/task/2625480598198926612) started by @mdjwel*