### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in OnePage Docs creation

### DIFF
--- a/includes/One_Page.php
+++ b/includes/One_Page.php
@@ -156,13 +156,13 @@ class One_Page {
             update_post_meta( $post_id, 'ezd_doc_content_type', $ezd_doc_content_type );
         }
         if ( $shortcode_content ) {
-            update_post_meta( $post_id, 'ezd_doc_left_sidebar', $shortcode_content );
+            update_post_meta( $post_id, 'ezd_doc_left_sidebar', wp_kses_post( $shortcode_content ) );
         }
         if ( $content_type_right ) {
             update_post_meta( $post_id, 'ezd_doc_content_type_right', $content_type_right );
         }
         if ( $shortcode_content_right ) {
-            update_post_meta( $post_id, 'ezd_doc_content_box_right', $shortcode_content_right );
+            update_post_meta( $post_id, 'ezd_doc_content_box_right', wp_kses_post( $shortcode_content_right ) );
         }
 
         // Store relation to original parent

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -993,7 +993,7 @@ add_action( 'save_post', function ( $post_id ) {
 	}
 
 	if ( ! empty( $ezd_doc_content_box_right ) ) {
-		update_post_meta( $post_id, 'ezd_doc_content_box_right', $ezd_doc_content_box_right );
+		update_post_meta( $post_id, 'ezd_doc_content_box_right', wp_kses_post( $ezd_doc_content_box_right ) );
 	}	
 
 } );


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Stored Cross-Site Scripting (XSS)
🎯 **Impact:** Authenticated users (Author+) could inject arbitrary JavaScript into documentation pages via the "One Page" layout creation parameters and meta fields (`ezd_doc_left_sidebar`, `ezd_doc_content_box_right`). This payload would execute for any user viewing the documentation, including administrators.
🔧 **Fix:** Applied `wp_kses_post()` to sanitize these fields before saving them to the database in both `includes/One_Page.php` (creation flow) and `includes/functions.php` (save post hook).
✅ **Verification:** Verified the code changes by inspection, ensuring `wp_kses_post()` wraps the input variables before `update_post_meta()` calls.

---
*PR created automatically by Jules for task [17278495016221014230](https://jules.google.com/task/17278495016221014230) started by @mdjwel*