### PR TITLE
🛡️ Sentinel: Fix weak nonce verification in document deletion

### DIFF
--- a/includes/Admin/Delete_Post.php
+++ b/includes/Admin/Delete_Post.php
@@ -34,7 +34,7 @@ class Delete_Post {
 			$delete_id  = sanitize_text_field( wp_unslash( $_GET['DeleteID'] ) );
 			$nonce      = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
 
-			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, $delete_id ) ) {
+			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_doc_' . $delete_id ) ) {
 				$posts     = intval( $delete_id );
 				$parent_id = $posts . ',';
 
@@ -81,7 +81,7 @@ class Delete_Post {
 			$section_id     = sanitize_text_field( wp_unslash( $_GET['ID'] ) );
 			$nonce          = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );	
 
-			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, $section_id ) ) {
+			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_doc_' . $section_id ) ) {
 				$posts     = intval( $section_id );
 				$parent_id = $posts . ',';
 

--- a/includes/Admin/template/parent-docs.php
+++ b/includes/Admin/template/parent-docs.php
@@ -91,7 +91,7 @@ $count = $query->found_posts;
                     <?php 
                      if ( ezd_is_admin_or_editor(get_the_ID(), 'delete') ) :
                         $delete_id = get_the_ID();
-                        $nonce     = wp_create_nonce( $delete_id );
+                        $nonce     = wp_create_nonce( 'ezd_delete_doc_' . $delete_id );
                         ?>
                         <a href="<?php echo esc_url( admin_url( 'admin.php' ) . '?Doc_Delete=yes&_wpnonce=' . $nonce . '&DeleteID=' . $delete_id ); ?>" class="link delete parent-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                             <span class="dashicons dashicons-trash"></span>

--- a/includes/Admin/template/template-parts.php
+++ b/includes/Admin/template/template-parts.php
@@ -215,7 +215,7 @@ function ezd_child_docs_left_content( $doc_item, $depth = 1, $item = []) {
              if ( ezd_is_admin_or_editor( $doc_item, 'delete' ) ) : 
                 ?>
                  <li class="delete">
-                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
+                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( 'ezd_delete_doc_' . $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                          <span class="dashicons dashicons-trash"></span>
                      </a>
                  </li>


### PR DESCRIPTION
🛡️ Sentinel: Fix weak nonce verification in document deletion

**Severity:** HIGH

**Vulnerability:** Weak Nonce Action
The plugin was generating and verifying nonces using only the document ID as the action (e.g., `wp_create_nonce($id)`). This is a security risk because nonces generated for other purposes (like editing) using the same ID could potentially be used to authorize deletion.

**Impact:** An attacker could potentially trick a user into deleting a document if they can obtain a valid nonce for another action involving that document ID.

**Fix:** Scoped the nonce action to `ezd_delete_doc_{id}`. This ensures that the nonce is valid *only* for the deletion of that specific document.

**Verification:**
- Verified `includes/Admin/template/parent-docs.php` generates nonces with the new prefix.
- Verified `includes/Admin/template/template-parts.php` generates nonces with the new prefix.
- Verified `includes/Admin/Delete_Post.php` verifies nonces against the new prefix.
- Ran `php -l` to ensure no syntax errors.

---
*PR created automatically by Jules for task [12852078099419837172](https://jules.google.com/task/12852078099419837172) started by @mdjwel*