### PR TITLE
⚡ Optimize sidebar reusable block query

### DIFF
--- a/templates/docs-right-sidebar.php
+++ b/templates/docs-right-sidebar.php
@@ -73,17 +73,10 @@ $toc_auto_numbering = $toc_auto_numbering == '1' ? ' toc_auto_numbering' : '';
 							dynamic_sidebar( 'doc_sidebar' );
 						}
 					} else {
-						if ( $content_type == 'widget_data_right' && ! empty( $is_valid_post_id ) ) {
-							$wp_blocks = new WP_Query( [
-								'post_type' => 'wp_block',
-								'p'         => $ezd_shortcode
-							] );
-
-							if ( $wp_blocks->have_posts() ) {
-								while ( $wp_blocks->have_posts() ) : $wp_blocks->the_post();
-									the_content();
-								endwhile;
-								wp_reset_postdata();
+						if ( 'widget_data_right' === $content_type && ! empty( $is_valid_post_id ) ) {
+							$wp_block = get_post( $ezd_shortcode );
+							if ( $wp_block && 'wp_block' === $wp_block->post_type && 'publish' === $wp_block->post_status ) {
+								echo apply_filters( 'the_content', $wp_block->post_content );
 							}
 						}
 					}


### PR DESCRIPTION
💡 **What:** Optimized the retrieval of reusable blocks in `templates/docs-right-sidebar.php` by replacing `new WP_Query()` with `get_post()`.
🎯 **Why:** `WP_Query` is resource-intensive for fetching a single post by ID. `get_post()` is lighter and utilizes the object cache (which is likely already primed). This reduces database load and parsing overhead.
📊 **Measured Improvement:** Benchmarking was not possible due to the isolated plugin environment, but `get_post()` is architecturally O(1) (cache hit) vs `WP_Query`'s SQL generation and execution. The optimization adheres to WordPress performance best practices for single-post retrieval.

---
*PR created automatically by Jules for task [8612269312264662851](https://jules.google.com/task/8612269312264662851) started by @mdjwel*