### PR TITLE
⚡ Fix memory leak in search banner event listeners

### DIFF
--- a/templates/search-banner.php
+++ b/templates/search-banner.php
@@ -52,6 +52,13 @@ jQuery(".focus_overlay").click(function() {
     jQuery('form.ezd_search_form').css('z-index', 'unset');
 })
 
+// Hide search results by pressing Escape button
+jQuery(document).keyup(function(e) {
+    if (e.key === "Escape") { // escape key maps to keycode `27`
+        jQuery('#ezd-search-results').removeClass('ajax-search').html("")
+    }
+});
+
 /**
  * Search Form Keywords
  */
@@ -88,12 +95,6 @@ function ezSearchResults() {
             },
             success: function(data) {
                 jQuery(".spinner-border").hide();
-                // hide search results by pressing Escape button
-                jQuery(document).keyup(function(e) {
-                    if (e.key === "Escape") { // escape key maps to keycode `27`
-                        jQuery('#ezd-search-results').removeClass('ajax-search').html("")
-                    }
-                });
                 if (data.length > 0) {
                     jQuery('#ezd-search-results').addClass('ajax-search').html(data);
                 } else {
@@ -138,13 +139,6 @@ jQuery('#ezd_searchInput').keyup(
                 },
                 success: function(data) {
                     jQuery(".spinner-border").hide();
-                    // hide search results by pressing Escape button
-                    jQuery(document).keyup(function(e) {
-                        if (e.key === "Escape") { // escape key maps to keycode `27`
-                            jQuery('#ezd-search-results').removeClass('ajax-search').html(
-                                "")
-                        }
-                    });
                     if (data.length > 0) {
                         jQuery('#ezd-search-results').addClass('ajax-search').html(data);
                     } else {


### PR DESCRIPTION
💡 **What:**
- Moved the `jQuery(document).keyup` event listener for closing search results with the Escape key from inside `ezSearchResults` and `ezdFetchDelay` callbacks to the top-level script scope.
- Removed duplicate listener definitions.

🎯 **Why:**
- Previously, a new event listener was attached to the `document` every time a search was successfully performed.
- This caused O(N) listeners to accumulate, where N is the number of searches, leading to increased memory usage and multiple handlers firing for a single keypress.

📊 **Measured Improvement:**
- **Baseline:** Linear growth of event listeners (O(N)) with each search.
- **Optimization:** Constant number of event listeners (O(1)), defined once on load.
- While exact browser metrics cannot be captured in this environment, the logic fix eliminates the leak mechanism entirely.

---
*PR created automatically by Jules for task [12712368481451846161](https://jules.google.com/task/12712368481451846161) started by @mdjwel*