### PR TITLE
⚡ Optimize docs sidebar child page check

### DIFF
--- a/templates/docs-sidebar.php
+++ b/templates/docs-sidebar.php
@@ -12,12 +12,9 @@ if ( $post->post_parent ) {
 
 $walker = new EazyDocs\Frontend\Walker_Docs();
 $children = array(
-    'title_li'    => '',
-    'order'       => 'menu_order',
-    'echo'        => false,
     'post_type'   => 'docs',
-    'walker'      => $walker,
     'post_status' => current_user_can( 'read_private_docs' ) ? [ 'publish', 'private', 'draft' ] : ['publish'],
+    'number'      => 1,
 );
 
 // If 'Self Docs' is selected, set 'child_of' to filter by the current doc.
@@ -26,7 +23,7 @@ if ( $sidebar_source === 'self_docs' || ! class_exists( 'EZD_EazyDocsPro' )  ) {
     $children['child_of'] = $parent;
 }
 
-$children           = wp_list_pages($children);
+$children           = get_pages( $children );
 $sidebar_search 	= ezd_get_opt( 'search_visibility', '1' );
 $content_layout 	= ezd_get_opt( 'docs_content_layout', '1' );
 $nav_sidebar_active = '';


### PR DESCRIPTION
Optimized the sidebar child page existence check in `templates/docs-sidebar.php`.

Previously, `wp_list_pages` was called to generate an HTML string solely to check if it was non-empty. This involved a full database query for all children and the CPU/memory overhead of the Walker class building the HTML tree.

This change replaces it with `get_pages` limited to `number => 1`. This query is much faster as it stops after finding the first match and returns a small array of objects instead of a large HTML string, avoiding the Walker entirely for this check.

The logic for `post_status` and `child_of` filtering is preserved. The variable `$children` now holds an array of posts (or empty array) instead of an HTML string, which is compatible with the boolean check `if ( $children )` used downstream.

---
*PR created automatically by Jules for task [10708553678904238646](https://jules.google.com/task/10708553678904238646) started by @mdjwel*