### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak nonce implementation using raw IDs as actions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The feedback form handler `eazydocs_feedback_email` allowed unlimited email submissions from unauthenticated users, leading to potential email spam and database flooding.
 **Learning:** Publicly accessible AJAX actions (`nopriv`) that trigger resource-intensive operations (sending emails, DB writes) must have rate limiting or CAPTCHA.
 **Prevention:** Implement IP-based transient rate limiting for all public-facing form handlers.
+
+## 2024-05-24 – Weak Nonce Action Usage (ID as Action)
+**Vulnerability:** `Create_Post.php` and `Delete_Post.php` used the raw Post ID (e.g., `$_GET['childID']`) as the nonce action. This increases the risk of nonce replay or collision if another component uses the ID as a nonce action for a less sensitive operation.
+**Learning:** Using variable IDs as nonce actions without namespacing is a recurring anti-pattern in this codebase. Additionally, `Last_Child_Delete` could not be patched because its generator source is hidden, forcing a "wontfix" decision to preserve compatibility.
+**Prevention:** Always prefix dynamic nonce actions with a context-specific string (e.g., `ezd_delete_doc_nonce_` . $id).

--- a/includes/Admin/Create_Post.php
+++ b/includes/Admin/Create_Post.php
@@ -47,7 +47,7 @@ class Create_Post {
 		// Handle section creation
 		if ( isset( $_GET['Create_Section'], $_GET['parentID'], $_GET['_wpnonce'], $_GET['is_section'] ) && 
 			 sanitize_text_field( wp_unslash( $_GET['Create_Section'] ) ) === 'yes' &&
-			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), sanitize_text_field( wp_unslash( $_GET['parentID'] ) ) ) ) {
+			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ezd_create_section_nonce_' . sanitize_text_field( wp_unslash( $_GET['parentID'] ) ) ) ) {
 			
 			$parent_id = absint( wp_unslash( $_GET['parentID'] ) );
 			$title = $this->sanitize_title( $_GET['is_section'] );
@@ -59,7 +59,7 @@ class Create_Post {
 		// Handle child creation
 		if ( isset( $_GET['Create_Child'], $_GET['childID'], $_GET['_wpnonce'], $_GET['child'] ) && 
 			 sanitize_text_field( wp_unslash( $_GET['Create_Child'] ) ) === 'yes' &&
-			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), sanitize_text_field( wp_unslash( $_GET['childID'] ) ) ) ) {
+			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ezd_create_child_nonce_' . sanitize_text_field( wp_unslash( $_GET['childID'] ) ) ) ) {
 			
 			$child_id = absint( wp_unslash( $_GET['childID'] ) );
 			$title = $this->sanitize_title( $_GET['child'] );

--- a/includes/Admin/Delete_Post.php
+++ b/includes/Admin/Delete_Post.php
@@ -34,7 +34,7 @@ class Delete_Post {
 			$delete_id  = sanitize_text_field( wp_unslash( $_GET['DeleteID'] ) );
 			$nonce      = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
 
-			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, $delete_id ) ) {
+			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_doc_nonce_' . $delete_id ) ) {
 				$posts     = intval( $delete_id );
 				$parent_id = $posts . ',';
 
@@ -81,7 +81,7 @@ class Delete_Post {
 			$section_id     = sanitize_text_field( wp_unslash( $_GET['ID'] ) );
 			$nonce          = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );	
 
-			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, $section_id ) ) {
+			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_section_nonce_' . $section_id ) ) {
 				$posts     = intval( $section_id );
 				$parent_id = $posts . ',';
 

--- a/includes/Admin/admin-helpers.php
+++ b/includes/Admin/admin-helpers.php
@@ -125,7 +125,7 @@ function ezd_render_doc_actions( $doc_id, $actions = ['duplicate', 'add_child', 
 
                 if ( $is_premium ) {
                     echo '<li>';
-                    echo '<a href="' . esc_url( admin_url( 'admin.php' ) ) . '?Create_Child=yes&childID=' . esc_attr( $doc_id ) . '&_wpnonce=' . esc_attr( wp_create_nonce( $doc_id ) ) . '&child=" class="child-doc" title="' . esc_attr__( 'Add new doc under this doc', 'eazydocs' ) . '">';
+                    echo '<a href="' . esc_url( admin_url( 'admin.php' ) ) . '?Create_Child=yes&childID=' . esc_attr( $doc_id ) . '&_wpnonce=' . esc_attr( wp_create_nonce( 'ezd_create_child_nonce_' . $doc_id ) ) . '&child=" class="child-doc" title="' . esc_attr__( 'Add new doc under this doc', 'eazydocs' ) . '">';
                     echo '<span class="dashicons dashicons-plus-alt2"></span>';
                     echo '</a>';
                     echo '</li>';

--- a/includes/Admin/template/child-docs.php
+++ b/includes/Admin/template/child-docs.php
@@ -161,7 +161,7 @@ if ( is_array( $depth_one_parents ) ) :
             <?php 
             if ( current_user_can( 'publish_docs' ) ) :                
                 $parent_id   = absint( $item );
-                $nonce       = wp_create_nonce( $parent_id );
+                $nonce       = wp_create_nonce( 'ezd_create_section_nonce_' . $parent_id );
                 ?>
                 <button class="button button-info section-doc" name="submit" data-url="<?php echo esc_url( admin_url( 'admin.php' ) . "?Create_Section=yes&_wpnonce={$nonce}&parentID={$parent_id}&is_section=" );; ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Add Section to %s', 'eazydocs' ), $parent_title ) ); ?>">
                     <?php esc_html_e( 'Add Section', 'eazydocs' ); ?>

--- a/includes/Admin/template/parent-docs.php
+++ b/includes/Admin/template/parent-docs.php
@@ -91,7 +91,7 @@ $count = $query->found_posts;
                     <?php 
                      if ( ezd_is_admin_or_editor(get_the_ID(), 'delete') ) :
                         $delete_id = get_the_ID();
-                        $nonce     = wp_create_nonce( $delete_id );
+                        $nonce     = wp_create_nonce( 'ezd_delete_doc_nonce_' . $delete_id );
                         ?>
                         <a href="<?php echo esc_url( admin_url( 'admin.php' ) . '?Doc_Delete=yes&_wpnonce=' . $nonce . '&DeleteID=' . $delete_id ); ?>" class="link delete parent-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                             <span class="dashicons dashicons-trash"></span>

--- a/includes/Admin/template/template-parts.php
+++ b/includes/Admin/template/template-parts.php
@@ -187,7 +187,7 @@ function ezd_child_docs_left_content( $doc_item, $depth = 1, $item = []) {
                  if ( $is_premium ) :
                      ?>
                      <li>
-                         <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Create_Child=yes&childID=<?php echo esc_attr($doc_item); ?>&_wpnonce=<?php echo esc_attr(wp_create_nonce($doc_item)); ?>&child=" class="child-doc" aria-label="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>" title="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>">
+                         <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Create_Child=yes&childID=<?php echo esc_attr($doc_item); ?>&_wpnonce=<?php echo esc_attr(wp_create_nonce('ezd_create_child_nonce_' . $doc_item)); ?>&child=" class="child-doc" aria-label="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>" title="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>">
                              <span class="dashicons dashicons-plus-alt2"></span>
                          </a>
                      </li>
@@ -215,7 +215,7 @@ function ezd_child_docs_left_content( $doc_item, $depth = 1, $item = []) {
              if ( ezd_is_admin_or_editor( $doc_item, 'delete' ) ) : 
                 ?>
                  <li class="delete">
-                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
+                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( 'ezd_delete_section_nonce_' . $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                          <span class="dashicons dashicons-trash"></span>
                      </a>
                  </li>


### PR DESCRIPTION
This PR addresses a security vulnerability where raw post IDs were used as nonce actions. 

**Vulnerability:**
Using a raw ID (e.g., `123`) as a nonce action allows for potential replay attacks or collisions if that ID is used as an action in multiple contexts (e.g., both deleting and creating, or in another plugin).

**Fix:**
Namespaced the nonce actions with specific context strings:
* `ezd_delete_doc_nonce_{ID}`
* `ezd_delete_section_nonce_{ID}`
* `ezd_create_child_nonce_{ID}`
* `ezd_create_section_nonce_{ID}`

**Changes:**
* Modified link/button generation in admin templates.
* Modified nonce verification in `Create_Post.php` and `Delete_Post.php` handlers.

**Verification:**
* Verified that new nonces are generated with the prefix.
* Verified that handlers check for the prefixed nonce.
* Ran `php -l` to ensure no syntax errors.

Note: `Last_Child_Delete` in `Delete_Post.php` was left unchanged as its generator source could not be identified, preserving backward compatibility (documented in `.jules/sentinel.md`).

---
*PR created automatically by Jules for task [11693940004670816770](https://jules.google.com/task/11693940004670816770) started by @mdjwel*