### PR TITLE
📋 Warden: Standardize WPCS (Yoda conditions, Strict comparisons, Short arrays)

### DIFF
--- a/includes/Admin/Admin.php
+++ b/includes/Admin/Admin.php
@@ -24,7 +24,7 @@ class Admin {
 	/**
 	 * Admin constructor.
 	 */
-	function __construct() {
+	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'eazyDocs_menu' ] );
 		add_action( 'admin_menu', [ $this, 'reorder_eazydocs_admin_submenu' ], 999 );
 		add_filter( 'admin_body_class', [ $this, 'body_class' ] );
@@ -50,8 +50,8 @@ class Admin {
 		$current_user_roles = (array) $user->roles;
 
 		// Documentation Authors Capabilities
-		$docs_write_access = ezd_get_opt( 'docs-write-access', array( 'administrator' ) );
-		$docs_write_access = is_array( $docs_write_access ) ? $docs_write_access : array( $docs_write_access );
+		$docs_write_access = ezd_get_opt( 'docs-write-access', [ 'administrator' ] );
+		$docs_write_access = is_array( $docs_write_access ) ? $docs_write_access : [ $docs_write_access ];
 
 		$docs_capability = 'manage_options';
 		foreach ( $current_user_roles as $role ) {
@@ -63,13 +63,13 @@ class Admin {
 
 		// Settings Managers Capabilities
 		$settings_capability = ezd_get_opt( 'settings-edit-access', 'manage_options' );
-		if ( ! in_array( $settings_capability, array( 'manage_options', 'publish_pages', 'publish_posts' ), true ) ) {
+		if ( ! in_array( $settings_capability, [ 'manage_options', 'publish_pages', 'publish_posts' ], true ) ) {
 			$settings_capability = 'manage_options';
 		}
 
 		// Analytics Viewers Capabilities
-		$analytics_access = ezd_get_opt( 'analytics-access', array( 'administrator' ) );
-		$analytics_access = is_array( $analytics_access ) ? $analytics_access : array( $analytics_access );
+		$analytics_access = ezd_get_opt( 'analytics-access', [ 'administrator' ] );
+		$analytics_access = is_array( $analytics_access ) ? $analytics_access : [ $analytics_access ];
 
 		$analytics_capability = 'manage_options';
 		$analytics_capability = 'manage_options';
@@ -92,16 +92,16 @@ class Admin {
 			$menu_title_with_badge = $ezd_menu_title . ' <span class="update-plugins" style="background-color: #00a32a; margin-left: 5px;"><span class="plugin-count" style="background-color: #00a32a;">PRO</span></span>';
 		}
 
-		add_menu_page( $ezd_menu_title, $menu_title_with_badge, $docs_capability, 'eazydocs', array( $this, 'eazydocs_dashboard' ), 'dashicons-media-document', 10 );
+		add_menu_page( $ezd_menu_title, $menu_title_with_badge, $docs_capability, 'eazydocs', [ $this, 'eazydocs_dashboard' ], 'dashicons-media-document', 10 );
 
-		add_submenu_page( 'eazydocs', esc_html__( 'Dashboard', 'eazydocs' ), esc_html__( 'Dashboard', 'eazydocs' ), $docs_capability, 'eazydocs', array( $this, 'eazydocs_dashboard' ) );
-		add_submenu_page( 'eazydocs', esc_html__( 'Docs Builder', 'eazydocs' ), esc_html__( 'Docs Builder', 'eazydocs' ), $docs_capability, 'eazydocs-builder', array( $this, 'eazydocs_builder' ) );
+		add_submenu_page( 'eazydocs', esc_html__( 'Dashboard', 'eazydocs' ), esc_html__( 'Dashboard', 'eazydocs' ), $docs_capability, 'eazydocs', [ $this, 'eazydocs_dashboard' ] );
+		add_submenu_page( 'eazydocs', esc_html__( 'Docs Builder', 'eazydocs' ), esc_html__( 'Docs Builder', 'eazydocs' ), $docs_capability, 'eazydocs-builder', [ $this, 'eazydocs_builder' ] );
 
 		$current_theme = get_template();
-		if ( $current_theme == 'docy' || $current_theme == 'docly' || ezd_is_premium() ) {
+		if ( 'docy' === $current_theme || 'docly' === $current_theme || ezd_is_premium() ) {
 			add_submenu_page( 'eazydocs', esc_html__( 'OnePage Docs', 'eazydocs' ), esc_html__( 'OnePage Docs', 'eazydocs' ), $settings_capability, '/edit.php?post_type=onepage-docs' );
 		} else {
-			add_submenu_page( 'eazydocs', esc_html__( 'OnePage Doc', 'eazydocs' ), esc_html__( 'OnePage Doc', 'eazydocs' ), $settings_capability, 'ezd-onepage-presents', array( $this, 'ezd_onepage_presents' ) );
+			add_submenu_page( 'eazydocs', esc_html__( 'OnePage Doc', 'eazydocs' ), esc_html__( 'OnePage Doc', 'eazydocs' ), $settings_capability, 'ezd-onepage-presents', [ $this, 'ezd_onepage_presents' ] );
 		}
 
 		add_submenu_page( 'eazydocs', esc_html__( 'Tags', 'eazydocs' ), esc_html__( 'Tags', 'eazydocs' ), $docs_capability, '/edit-tags.php?taxonomy=doc_tag&post_type=docs' );
@@ -115,8 +115,8 @@ class Admin {
 		if ( ezd_is_premium() ) {
 			do_action( 'ezd_pro_admin_menu' );
 		} else {
-			add_submenu_page( 'eazydocs', esc_html__( 'Users Feedback', 'eazydocs' ), esc_html__( 'Users Feedback', 'eazydocs' ), $analytics_capability, 'ezd-user-feedback', array( $this, 'ezd_feedback_presents' ) );
-			add_submenu_page( 'eazydocs', esc_html__( 'Analytics', 'eazydocs' ), esc_html__( 'Analytics', 'eazydocs' ), $analytics_capability, 'ezd-analytics', array( $this, 'ezd_analytics_presents' ) );
+			add_submenu_page( 'eazydocs', esc_html__( 'Users Feedback', 'eazydocs' ), esc_html__( 'Users Feedback', 'eazydocs' ), $analytics_capability, 'ezd-user-feedback', [ $this, 'ezd_feedback_presents' ] );
+			add_submenu_page( 'eazydocs', esc_html__( 'Analytics', 'eazydocs' ), esc_html__( 'Analytics', 'eazydocs' ), $analytics_capability, 'ezd-analytics', [ $this, 'ezd_analytics_presents' ] );
 		}
 
 		// Only show FAQ Builder menu if neither the free nor pro version of Advanced Accordion Block is active
@@ -125,12 +125,12 @@ class Admin {
 		}
 
 		if ( ! is_plugin_active( 'advanced-accordion-block/advanced-accordion-block.php' ) && ! is_plugin_active( 'advanced-accordion-block-pro/advanced-accordion-block.php' ) ) {
-			add_submenu_page( 'eazydocs', esc_html__( 'FAQ Builder', 'eazydocs' ), esc_html__( 'FAQ Builder', 'eazydocs' ), $docs_capability, 'ezd-faq-builder', array( $this, 'ezd_faq_builder' ) );
+			add_submenu_page( 'eazydocs', esc_html__( 'FAQ Builder', 'eazydocs' ), esc_html__( 'FAQ Builder', 'eazydocs' ), $docs_capability, 'ezd-faq-builder', [ $this, 'ezd_faq_builder' ] );
 		}
 
-		add_submenu_page( 'eazydocs', esc_html__( 'Integrated Themes', 'eazydocs' ), esc_html__( 'Integrated Themes', 'eazydocs' ), $settings_capability, 'ezd-integrated-themes', array( $this, 'ezd_integrated_themes' ) );
-		add_submenu_page( 'eazydocs', esc_html__( 'Setup Wizard', 'eazydocs' ), esc_html__( 'Setup Wizard', 'eazydocs' ), $settings_capability, 'eazydocs-initial-setup', array( $this, 'ezd_setup_wizard' ) );
-		add_submenu_page( 'eazydocs', esc_html__( 'Migration', 'eazydocs' ), esc_html__( 'Migration', 'eazydocs' ), $settings_capability, 'eazydocs-migration', array( $this, 'ezd_docs_migration' ) );
+		add_submenu_page( 'eazydocs', esc_html__( 'Integrated Themes', 'eazydocs' ), esc_html__( 'Integrated Themes', 'eazydocs' ), $settings_capability, 'ezd-integrated-themes', [ $this, 'ezd_integrated_themes' ] );
+		add_submenu_page( 'eazydocs', esc_html__( 'Setup Wizard', 'eazydocs' ), esc_html__( 'Setup Wizard', 'eazydocs' ), $settings_capability, 'eazydocs-initial-setup', [ $this, 'ezd_setup_wizard' ] );
+		add_submenu_page( 'eazydocs', esc_html__( 'Migration', 'eazydocs' ), esc_html__( 'Migration', 'eazydocs' ), $settings_capability, 'eazydocs-migration', [ $this, 'ezd_docs_migration' ] );
 	}
 
 
@@ -305,7 +305,7 @@ class Admin {
 			$classes .= ' ezd-premium';
 		}
 
-		if ( eaz_fs()->is_plan( 'promax' ) == "yes" ) {
+		if ( eaz_fs()->is_plan( 'promax' ) ) {
 			$classes .= ' ezd-promax';
 		}
 
@@ -428,7 +428,7 @@ class Admin {
 	 * @return mixed|string
 	 */
 	public function one_page_docs_edit_content( $link, $post_ID ) {
-		if ( 'onepage-docs' == get_post_type( $post_ID ) ) {
+		if ( 'onepage-docs' === get_post_type( $post_ID ) ) {
 			$is_content = get_post_meta( $post_ID, 'ezd_doc_left_sidebar', true );
 
 			$ezd_doc_layout = get_post_meta( $post_ID, 'ezd_doc_layout', true );
@@ -445,7 +445,7 @@ class Admin {
 			$content_type_right     = ! empty( $ezd_content_type_right ) ? '&content_type_right=' . $ezd_content_type_right : null;
 
 			$ezd_content_right = '';
-			if ( $ezd_content_type_right == 'widget_data_right' ) {
+			if ( 'widget_data_right' === $ezd_content_type_right ) {
 				$ezd_content_right = get_post_meta( $post_ID, 'ezd_doc_content_box_right', true );
 			} else {
 				$ezd_content_right = get_post_meta( $post_ID, 'ezd_doc_content_box_right', true );
@@ -574,17 +574,17 @@ class Admin {
 		$private_mode     = ezd_is_premium() ? ezd_get_opt( 'private_doc_mode' ) : 'none';
 		$is_contribution  = ezd_is_promax() ? ezd_get_opt( 'is_doc_contribution' ) : false;
 
-		if ( $post->ID == $docs_slug_page ) {
+		if ( $post->ID === (int) $docs_slug_page ) {
 			$post_states['docs_archive'] = __( 'Docs Archive', 'eazydocs' );
 		}
 
-		if ( $login_page === $frontend_login && $post->ID == $login_page ) {
+		if ( $login_page === $frontend_login && $post->ID === (int) $login_page ) {
 			$post_states['docs_login'] = __( 'Docs Access', 'eazydocs' );
 		} else {
-			if ( $post->ID == $login_page && $private_mode === 'login' ) {
+			if ( $post->ID === (int) $login_page && 'login' === $private_mode ) {
 				$post_states['docs_login'] = __( 'Private Access', 'eazydocs' );
 			}
-			if ( $post->ID == $frontend_login && $is_contribution ) {
+			if ( $post->ID === (int) $frontend_login && $is_contribution ) {
 				$post_states['docs_collaborator'] = __( 'Collaborator Access', 'eazydocs' );
 			}
 		}

--- a/includes/Frontend/Ajax.php
+++ b/includes/Frontend/Ajax.php
@@ -50,7 +50,7 @@ class Ajax {
 		}
 
 		$post_id  = intval( $_POST['post_id'] );
-		$type     = in_array( $_POST['type'], [ 'positive', 'negative' ] ) ? sanitize_text_field( $_POST['type'] ) : false;
+		$type     = in_array( $_POST['type'], [ 'positive', 'negative' ], true ) ? sanitize_text_field( $_POST['type'] ) : false;
 
 		// check previous response
 		if ( in_array( $post_id, $previous ) ) {
@@ -138,7 +138,7 @@ class Ajax {
 
 		//  Content matches (only if mode allows)
 		$content_ids = [];
-		if ( $search_mode === 'title_and_content' ) {
+		if ( 'title_and_content' === $search_mode ) {
 			$content_ids = $wpdb->get_col($wpdb->prepare("
 				SELECT ID FROM {$wpdb->posts}
 				WHERE post_type = 'docs'
@@ -177,7 +177,7 @@ class Ajax {
 			'orderby'        => [
 				'post__in'    => 'ASC',
 				'menu_order'  => 'ASC',
-				'date'        => get_option('posts_order') === 'asc' ? 'ASC' : 'DESC',
+				'date'        => 'asc' === get_option('posts_order') ? 'ASC' : 'DESC',
 				'title'       => 'ASC',
 			],
 		];
@@ -225,7 +225,7 @@ class Ajax {
 		// --- OUTPUT RESULTS (unchanged) ---
 		if ( $posts->have_posts() ) :
 			while ( $posts->have_posts() ) : $posts->the_post();
-				$no_thumbnail = ezd_get_opt('is_search_result_thumbnail') == false ? 'no-thumbnail' : '';
+				$no_thumbnail = ! ezd_get_opt('is_search_result_thumbnail') ? 'no-thumbnail' : '';
 				?>
 				<div class="search-result-item <?php echo esc_attr($no_thumbnail); ?>" data-url="<?php the_permalink(); ?>">
 					<a href="<?php the_permalink(); ?>" class="title">
@@ -276,7 +276,7 @@ class Ajax {
 
 		// Validate post ID
 		if ($postid <= 0) {
-			wp_send_json_error(array('message' => esc_html__('Invalid document ID', 'eazydocs')));
+			wp_send_json_error(['message' => esc_html__('Invalid document ID', 'eazydocs')]);
 			return;
 		}
 
@@ -293,9 +293,9 @@ class Ajax {
 					$has_access = is_user_logged_in();
 				} else {
 					// Specific roles only
-					$allowed_roles   = ezd_get_opt( 'private_doc_allowed_roles', array( 'administrator', 'editor' ) );
+					$allowed_roles   = ezd_get_opt( 'private_doc_allowed_roles', [ 'administrator', 'editor' ] );
 					if ( ! is_array( $allowed_roles ) ) {
-						$allowed_roles = array( $allowed_roles );
+						$allowed_roles = [ $allowed_roles ];
 					}
 					
 					$current_user_id = get_current_user_id();
@@ -316,7 +316,7 @@ class Ajax {
 					$current_user_id   = get_current_user_id();
 					$current_user      = new \WP_User( $current_user_id );
 					$current_roles     = (array) $current_user->roles;
-					$private_doc_roles = $user_group['private_doc_roles'] ?? array();
+					$private_doc_roles = $user_group['private_doc_roles'] ?? [];
 					$matching_roles    = array_intersect( $current_roles, $private_doc_roles );
 					
 					$has_access = ! empty( $matching_roles ) || current_user_can( 'manage_options' );
@@ -325,13 +325,13 @@ class Ajax {
 			
 			if ( ! $has_access ) {
 				$denied_message = ezd_get_opt( 'role_visibility_denied_message', esc_html__( 'You don\'t have permission to access this document!', 'eazydocs' ) );
-				wp_send_json_error( array( 'message' => esc_html( $denied_message ) ) );
+				wp_send_json_error( [ 'message' => esc_html( $denied_message ) ] );
 				return;
 			}
 		}
 
 		global $post, $wp_query;
-		$wp_query 		= new \WP_Query( array( 'post_type' => 'docs', 'p' => $postid ) );
+		$wp_query 		= new \WP_Query( [ 'post_type' => 'docs', 'p' => $postid ] );
 		$modified 		= '';
 		$html 			= '';
 
@@ -358,9 +358,9 @@ class Ajax {
 
 		$html = ob_get_clean();
 
-		return wp_send_json_success( array(
+		return wp_send_json_success( [
 			'content'         => $html,
 			'modified_date'   => $modified
-		) );
+		] );
 	}
 }

--- a/includes/Frontend/Walker_Docs.php
+++ b/includes/Frontend/Walker_Docs.php
@@ -32,10 +32,10 @@ class Walker_Docs extends Walker_Page {
 	 *
 	 * @see   Walker::$db_fields
 	 */
-	public $db_fields = array(
+	public $db_fields = [
 		'parent' => 'post_parent',
 		'id'     => 'ID',
-	);
+	];
 
 	public static $parent_item       = false;
 	public static $parent_item_class = '';
@@ -62,15 +62,15 @@ class Walker_Docs extends Walker_Page {
 	}
 
 	private function get_item_spacing( $args ) {
-		return isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ? array( "\t", "\n" ) : array( '', '' );
+		return isset( $args['item_spacing'] ) && 'preserve' === $args['item_spacing'] ? [ "\t", "\n" ] : [ '', '' ];
 	}
 
-	public function start_lvl( &$output, $depth = 0, $args = array() ) {
+	public function start_lvl( &$output, $depth = 0, $args = [] ) {
 		$indent  = str_repeat( "\t", $depth );
 		$output .= '<span class="icon"><i class="arrow_carrot-down"></i></span> </div>' . "\n$indent<ul class='dropdown_nav'>\n";
 
-		if ( $args['has_children'] && $depth == 0 ) {
-			$classes = isset( self::$parent_item->ID ) ? array( 'page_item', 'extra-class', 'page-item-' . self::$parent_item->ID ) : '';
+		if ( $args['has_children'] && 0 === $depth ) {
+			$classes = isset( self::$parent_item->ID ) ? [ 'page_item', 'extra-class', 'page-item-' . self::$parent_item->ID ] : '';
 
 			if ( self::$parent_item_class ) {
 				$classes[] = self::$parent_item_class;
@@ -90,7 +90,7 @@ class Walker_Docs extends Walker_Page {
 	 *
 	 * @since 2.1.0
 	 */
-	public function end_lvl( &$output, $depth = 0, $args = array() ) {
+	public function end_lvl( &$output, $depth = 0, $args = [] ) {
 		list( $t, $n ) = $this->get_item_spacing( $args );
 		$indent        = str_repeat( $t, $depth );
 		$output       .= "{$indent}</ul>{$n}";
@@ -109,7 +109,7 @@ class Walker_Docs extends Walker_Page {
 	 *
 	 * @see   Walker::start_el()
 	 */
-	public function start_el( &$output, $page, $depth = 0, $args = array(), $current_page = 0 ) {
+	public function start_el( &$output, $page, $depth = 0, $args = [], $current_page = 0 ) {
 
 		$icon_type = ezd_get_opt( 'doc_sec_icon_type', false );
 
@@ -119,7 +119,7 @@ class Walker_Docs extends Walker_Page {
 		$has_post_thumb = ! has_post_thumbnail( $page->ID ) ? 'no_icon' : '';
 		$has_child      = isset( $args['pages_with_children'][ $page->ID ] ) ? 'has_child' : '';
 
-		$css_class = array( 'nav-item', $has_post_thumb, $has_child, 'page-item-' . $page->ID );
+		$css_class = [ 'nav-item', $has_post_thumb, $has_child, 'page-item-' . $page->ID ];
 
 		// Add post status class
 		$css_class[] = 'post-status-' . $page->post_status;
@@ -129,12 +129,12 @@ class Walker_Docs extends Walker_Page {
 			if ( $_current_page && in_array( $page->ID, $_current_page->ancestors ) ) {
 				$css_class[] = 'current_page_ancestor active';
 			}
-			if ( $page->ID == $current_page ) {
+			if ( $page->ID === $current_page ) {
 				$css_class[] = 'current_page_item active';
-			} elseif ( $_current_page && $page->ID == $_current_page->post_parent ) {
+			} elseif ( $_current_page && $page->ID === $_current_page->post_parent ) {
 				$css_class[] = 'current_page_parent';
 			}
-		} elseif ( $page->ID == get_option( 'page_for_posts' ) ) {
+		} elseif ( $page->ID === (int) get_option( 'page_for_posts' ) ) {
 			$css_class[] = 'current_page_parent';
 		}
 
@@ -160,7 +160,7 @@ class Walker_Docs extends Walker_Page {
 		}
 
 		$thumb = '';
-		if ( $depth == 0 ) {
+		if ( 0 === $depth ) {
 			$doc_sec_icon_open = ezd_get_opt( 'doc_sec_icon_open' );
 			$folder_open       = is_array( $doc_sec_icon_open ) && ! empty( $doc_sec_icon_open['url'] )
 				? $doc_sec_icon_open['url']
@@ -184,18 +184,18 @@ class Walker_Docs extends Walker_Page {
 
 		$args['link_after'] = $link_after;
 
-		$atts                = array();
+		$atts                = [];
 		$atts['href']        = get_permalink( $page->ID );
 		$atts['data-postid'] = $page->ID;
-		if ( $page->ID == $current_page ) {
+		if ( $page->ID === $current_page ) {
 			$atts['class'] = 'active';
 		}
 		$doc_link = '';
-		if ( isset( $args['pages_with_children'][ $page->ID ] ) || $depth == 0 ) {
+		if ( isset( $args['pages_with_children'][ $page->ID ] ) || 0 === $depth ) {
 			$atts['class'] = 'nav-link';
 			$doc_link      = '<div class="doc-link">';
 		}
-		$atts['aria-current'] = ( $page->ID == $current_page ) ? 'page' : '';
+		$atts['aria-current'] = ( $page->ID === $current_page ) ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a page menu item's anchor element.
@@ -250,7 +250,7 @@ class Walker_Docs extends Walker_Page {
 	 *
 	 * @see   Walker::end_el()
 	 */
-	public function end_el( &$output, $page, $depth = 0, $args = array() ) {
+	public function end_el( &$output, $page, $depth = 0, $args = [] ) {
 		list( $t, $n ) = $this->get_item_spacing( $args );
 		$output       .= "</li>{$n}";
 	}
@@ -274,7 +274,7 @@ class Walker_Docs extends Walker_Page {
 		}
 
 		$output       = '';
-		$is_private   = $page->post_status == 'private';
+		$is_private   = 'private' === $page->post_status;
 		$has_password = ! empty( $page->post_password );
 
 		// Check for role-based visibility


### PR DESCRIPTION
##  Warden: Standardize WPCS (Yoda conditions, Strict comparisons, Short arrays)

### 💡 What Changed
- Refactored `includes/Admin/Admin.php`:
    - Converted `array()` to `[]`.
    - Enforced strict comparisons (`===`) and Yoda conditions.
    - Fixed `eaz_fs()->is_plan()` check to use boolean logic instead of string comparison.
- Refactored `includes/Frontend/Walker_Docs.php`:
    - Converted `array()` to `[]`.
    - Enforced strict comparisons and Yoda conditions (e.g., `0 === $depth`).
- Refactored `includes/Frontend/Ajax.php`:
    - Converted `array()` to `[]` in `docs_single_content`.
    - Replaced loose check `== false` with `! ezd_get_opt(...)` for better boolean handling.

### 🎯 Why
- Addresses inconsistencies in coding style across core files.
- Improves type safety by using strict comparisons.
- Aligns with WordPress Coding Standards (Yoda conditions).
- Modernizes syntax (Short array syntax).
- **Correction:** Fixed a potential bug where `eaz_fs()->is_plan()` (returning boolean) was compared to string "yes".

### 📊 Impact
- **Code quality:** Consistent style and safer comparisons.
- **Behavior:** No functional changes intended (except fixing the potentially broken "promax" check which might now work correctly if it was failing before, or just cleaner logic).

### 🧪 How Tested
- [x] PHP Syntax Check: `php -l` passed for all modified files.
- [x] Manual Review: Verified logic changes, especially around `is_plan` and `ezd_get_opt`.

### 🧩 Compatibility Notes
- PHP: 7.4+ (required by plugin) supports all these changes.
- WordPress: Standard APIs used.

### 📋 Checklist
- [x] No breaking changes to public hooks/filters
- [x] No functional/behavior changes (style/quality only)
- [x] Changes scoped to stated theme only

---
*PR created automatically by Jules for task [6308043794930321473](https://jules.google.com/task/6308043794930321473) started by @mdjwel*