### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in OnePage Docs

### DIFF
--- a/.sentinel/journal.md
+++ b/.sentinel/journal.md
@@ -1,0 +1,5 @@
+## 2024-05-23 - Stored XSS in OnePage Docs
+
+**Vulnerability:** Stored XSS in `One_Page.php` and `functions.php` where user input from `$_GET` and `$_POST` was saved to post meta without sanitization and output via `do_shortcode`.
+**Learning:** `do_shortcode` does not sanitize output; it only expands shortcodes. Always sanitize input before saving to database, especially for rich text fields using `wp_kses_post`.
+**Prevention:** Use `wp_kses_post` for rich text/HTML content and `sanitize_text_field` for plain text inputs.

--- a/includes/One_Page.php
+++ b/includes/One_Page.php
@@ -156,13 +156,15 @@ class One_Page {
             update_post_meta( $post_id, 'ezd_doc_content_type', $ezd_doc_content_type );
         }
         if ( $shortcode_content ) {
-            update_post_meta( $post_id, 'ezd_doc_left_sidebar', $shortcode_content );
+            // Sentinel: Sanitize content to prevent Stored XSS
+            update_post_meta( $post_id, 'ezd_doc_left_sidebar', wp_kses_post( $shortcode_content ) );
         }
         if ( $content_type_right ) {
             update_post_meta( $post_id, 'ezd_doc_content_type_right', $content_type_right );
         }
         if ( $shortcode_content_right ) {
-            update_post_meta( $post_id, 'ezd_doc_content_box_right', $shortcode_content_right );
+            // Sentinel: Sanitize content to prevent Stored XSS
+            update_post_meta( $post_id, 'ezd_doc_content_box_right', wp_kses_post( $shortcode_content_right ) );
         }
 
         // Store relation to original parent

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1018,10 +1018,10 @@ add_action( 'save_post', function ( $post_id ) {
 		return;
 	}
 
-	$std_comment_id             = $_POST['ezd_doc_layout'] ?? '';
-	$ezd_doc_content_type       = $_POST['ezd_doc_content_type'] ?? '';
-	$ezd_doc_content_type_right = $_POST['ezd_doc_content_type_right'] ?? '';
-	$ezd_doc_content_box_right  = $_POST['ezd_doc_content_box_right'] ?? '';
+	$std_comment_id             = sanitize_text_field( $_POST['ezd_doc_layout'] ?? '' );
+	$ezd_doc_content_type       = sanitize_text_field( $_POST['ezd_doc_content_type'] ?? '' );
+	$ezd_doc_content_type_right = sanitize_text_field( $_POST['ezd_doc_content_type_right'] ?? '' );
+	$ezd_doc_content_box_right  = wp_kses_post( $_POST['ezd_doc_content_box_right'] ?? '' );
 
 	if ( ! empty( $std_comment_id ) ) {
 		update_post_meta( $post_id, 'ezd_doc_layout', $std_comment_id );
@@ -1036,6 +1036,7 @@ add_action( 'save_post', function ( $post_id ) {
 	}
 
 	if ( ! empty( $ezd_doc_content_box_right ) ) {
+        // Sentinel: Sanitize content to prevent Stored XSS
 		update_post_meta( $post_id, 'ezd_doc_content_box_right', $ezd_doc_content_box_right );
 	}	
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS in OnePage Docs

**Severity:** HIGH
**Vulnerability:** Stored Cross-Site Scripting (XSS) via unsanitized inputs in OnePage Docs creation and update.
**Impact:** Administrators or Editors could inadvertently store malicious scripts that execute on the frontend when viewing the document, potentially compromising site integrity or stealing session cookies.
**Fix:** Applied `wp_kses_post()` to sanitize rich text inputs and `sanitize_text_field()` for plain text inputs before saving to the database.
**Verification:** Validated code changes with syntax check `php -l`. Code review approved the changes.


---
*PR created automatically by Jules for task [17569474273876141102](https://jules.google.com/task/17569474273876141102) started by @mdjwel*