### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix weak nonce actions for doc deletion and creation

### DIFF
--- a/.sentinel/journal.md
+++ b/.sentinel/journal.md
@@ -1,0 +1,5 @@
+## 2026-02-09 - Weak Nonce Actions on Resource IDs
+
+**Vulnerability:** Nonces were generated using only the resource ID (e.g. `wp_create_nonce( $post_id )`) for multiple distinct actions (Delete Doc, Create Child, Create Section).
+**Learning:** Using raw IDs as nonce actions creates ambiguity and potential reuse vulnerabilities if an attacker can obtain a nonce for that ID from a different context.
+**Prevention:** Always namespace nonce actions with a specific prefix (e.g. `action_name_` . $id) to ensure they are scoped to the intended operation.

--- a/includes/Admin/Create_Post.php
+++ b/includes/Admin/Create_Post.php
@@ -47,7 +47,7 @@ class Create_Post {
 		// Handle section creation
 		if ( isset( $_GET['Create_Section'], $_GET['parentID'], $_GET['_wpnonce'], $_GET['is_section'] ) && 
 			 sanitize_text_field( wp_unslash( $_GET['Create_Section'] ) ) === 'yes' &&
-			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), sanitize_text_field( wp_unslash( $_GET['parentID'] ) ) ) ) {
+			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ezd_create_section_nonce_' . sanitize_text_field( wp_unslash( $_GET['parentID'] ) ) ) ) {
 			
 			$parent_id = absint( wp_unslash( $_GET['parentID'] ) );
 			$title = $this->sanitize_title( $_GET['is_section'] );
@@ -59,7 +59,7 @@ class Create_Post {
 		// Handle child creation
 		if ( isset( $_GET['Create_Child'], $_GET['childID'], $_GET['_wpnonce'], $_GET['child'] ) && 
 			 sanitize_text_field( wp_unslash( $_GET['Create_Child'] ) ) === 'yes' &&
-			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), sanitize_text_field( wp_unslash( $_GET['childID'] ) ) ) ) {
+			 wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ezd_create_child_nonce_' . sanitize_text_field( wp_unslash( $_GET['childID'] ) ) ) ) {
 			
 			$child_id = absint( wp_unslash( $_GET['childID'] ) );
 			$title = $this->sanitize_title( $_GET['child'] );

--- a/includes/Admin/Delete_Post.php
+++ b/includes/Admin/Delete_Post.php
@@ -34,7 +34,7 @@ class Delete_Post {
 			$delete_id  = sanitize_text_field( wp_unslash( $_GET['DeleteID'] ) );
 			$nonce      = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
 
-			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, $delete_id ) ) {
+			if ( $doc_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_doc_nonce_' . $delete_id ) ) {
 				$posts     = intval( $delete_id );
 				$parent_id = $posts . ',';
 
@@ -81,7 +81,7 @@ class Delete_Post {
 			$section_id     = sanitize_text_field( wp_unslash( $_GET['ID'] ) );
 			$nonce          = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );	
 
-			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, $section_id ) ) {
+			if ( $section_delete === 'yes' && wp_verify_nonce( $nonce, 'ezd_delete_section_nonce_' . $section_id ) ) {
 				$posts     = intval( $section_id );
 				$parent_id = $posts . ',';
 

--- a/includes/Admin/template/child-docs.php
+++ b/includes/Admin/template/child-docs.php
@@ -161,7 +161,7 @@ if ( is_array( $depth_one_parents ) ) :
             <?php 
             if ( current_user_can( 'publish_docs' ) ) :                
                 $parent_id   = absint( $item );
-                $nonce       = wp_create_nonce( $parent_id );
+                $nonce       = wp_create_nonce( 'ezd_create_section_nonce_' . $parent_id );
                 ?>
                 <button class="button button-info section-doc" name="submit" data-url="<?php echo esc_url( admin_url( 'admin.php' ) . "?Create_Section=yes&_wpnonce={$nonce}&parentID={$parent_id}&is_section=" );; ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Add Section to %s', 'eazydocs' ), $parent_title ) ); ?>">
                     <?php esc_html_e( 'Add Section', 'eazydocs' ); ?>

--- a/includes/Admin/template/parent-docs.php
+++ b/includes/Admin/template/parent-docs.php
@@ -91,7 +91,7 @@ $count = $query->found_posts;
                     <?php 
                      if ( ezd_is_admin_or_editor(get_the_ID(), 'delete') ) :
                         $delete_id = get_the_ID();
-                        $nonce     = wp_create_nonce( $delete_id );
+                        $nonce     = wp_create_nonce( 'ezd_delete_doc_nonce_' . $delete_id );
                         ?>
                         <a href="<?php echo esc_url( admin_url( 'admin.php' ) . '?Doc_Delete=yes&_wpnonce=' . $nonce . '&DeleteID=' . $delete_id ); ?>" class="link delete parent-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                             <span class="dashicons dashicons-trash"></span>

--- a/includes/Admin/template/template-parts.php
+++ b/includes/Admin/template/template-parts.php
@@ -187,7 +187,7 @@ function ezd_child_docs_left_content( $doc_item, $depth = 1, $item = []) {
                  if ( $is_premium ) :
                      ?>
                      <li>
-                         <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Create_Child=yes&childID=<?php echo esc_attr($doc_item); ?>&_wpnonce=<?php echo esc_attr(wp_create_nonce($doc_item)); ?>&child=" class="child-doc" aria-label="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>" title="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>">
+                         <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Create_Child=yes&childID=<?php echo esc_attr($doc_item); ?>&_wpnonce=<?php echo esc_attr(wp_create_nonce('ezd_create_child_nonce_' . $doc_item)); ?>&child=" class="child-doc" aria-label="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>" title="<?php esc_attr_e('Add new doc under this doc', 'eazydocs'); ?>">
                              <span class="dashicons dashicons-plus-alt2"></span>
                          </a>
                      </li>
@@ -215,7 +215,7 @@ function ezd_child_docs_left_content( $doc_item, $depth = 1, $item = []) {
              if ( ezd_is_admin_or_editor( $doc_item, 'delete' ) ) : 
                 ?>
                  <li class="delete">
-                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
+                     <a href="<?php echo esc_url(admin_url('admin.php')); ?>?Section_Delete=yes&_wpnonce=<?php echo esc_attr( wp_create_nonce( 'ezd_delete_section_nonce_' . $doc_item ) ); ?>&ID=<?php echo esc_attr( $doc_item ); ?>" class="section-delete" aria-label="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'eazydocs' ); ?>">
                          <span class="dashicons dashicons-trash"></span>
                      </a>
                  </li>


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Nonces were generated using only the resource ID (e.g., `wp_create_nonce( $post_id )`) for multiple distinct actions (Delete Doc, Create Child, Create Section). This allows potential nonce reuse if an attacker can obtain a valid nonce for that ID from another context.
🎯 **Impact:** An attacker could potentially perform unintended actions (e.g., deleting a document instead of just creating a child, if the nonce happened to match or be reused) by manipulating the request parameters, although unlikely without separate nonce leaks, it is a significant security weakness.
🔧 **Fix:** Refactored nonce generation and verification to include specific action prefixes (e.g., `ezd_delete_doc_nonce_` . $post_id), ensuring nonces are scoped to their intended operation.
✅ **Verification:** Verified that `Create_Section`, `Create_Child`, `Doc_Delete`, and `Section_Delete` links now contain the updated nonce actions and that the backend handlers verify against these specific actions.

---
*PR created automatically by Jules for task [11065017876300712315](https://jules.google.com/task/11065017876300712315) started by @mdjwel*