### PR TITLE
🔧 Forge: Optimize search performance with ID caching & query limits

### DIFF
--- a/includes/Frontend/Ajax.php
+++ b/includes/Frontend/Ajax.php
@@ -119,8 +119,9 @@ class Ajax {
 		}
 
 		// Optimization: Check for cached IDs to skip expensive LIKE queries
-		$cache_key = 'ezd_search_ids_' . md5( $keyword . '_' . $search_mode . '_' . ( $can_read_private ? 'private' : 'public' ) );
-		$final_ids = get_transient( $cache_key );
+		$normalized_keyword = strtolower( trim( $keyword ) );
+		$cache_key          = 'ezd_search_ids_' . md5( $normalized_keyword . '_' . $search_mode . '_' . ( $can_read_private ? 'private' : 'public' ) );
+		$final_ids          = get_transient( $cache_key );
 
 		if ( false === $final_ids ) {
 			// --- SEARCH LOGIC (Cache Miss) ---


### PR DESCRIPTION
💡 **What:**
- Replaced redundant/broken HTML output caching with robust transient caching of search result IDs (`$final_ids`).
- Limited search results to 20 items per page (`posts_per_page => 20`) to improve performance on broad queries.
- Updated search logging to use `$posts->found_posts` for accurate analytics despite pagination limits.
- Optimized the "search log table existence" check to run once every 24h (cached in transient) instead of on every search request.

🎯 **Why:**
- **Saves server resources:** Eliminates 3 expensive `LIKE` queries for identical repeated searches (cache hit).
- **Improves scalability:** Limiting results prevents memory exhaustion on broad terms (e.g. "the").
- **Fixes analytics:** The previous HTML cache implementation skipped logging entirely for cached hits. The new ID cache allows logging to run consistently.
- **Reduces DB load:** Removing per-request `SHOW TABLES LIKE` queries saves 2 DB round-trips per search.

📊 **Impact:**
- Admins/Users get faster search results.
- Database load significantly reduced during high traffic.
- Search analytics become more accurate and complete.

🔬 **How to test:**
1. Perform a search for a term with many results (e.g. "a").
2. Verify only 20 results are returned in the UI.
3. Check the database `wp_eazydocs_search_log` table:
   - `count` should reflect the *total* matches (e.g. 100), not the limited count (20).
4. Perform the same search again immediately.
   - The result should appear instantly (served from ID cache).
   - The log should still record the search (with correct count).

♻️ **Backward compatible:**
- Fully compatible. The search behavior (relevance sorting: Exact > Partial > Content) is preserved via `orderby => post__in`.

---
*PR created automatically by Jules for task [11273422839705582967](https://jules.google.com/task/11273422839705582967) started by @mdjwel*