### PR TITLE
📋 Warden: WPCS & Formatting Cleanup

### DIFF
--- a/eazydocs.php
+++ b/eazydocs.php
@@ -100,7 +100,7 @@ if ( ! class_exists( 'EazyDocs' ) ) {
 					}
 
 					$is_dev_mode = defined( 'DEVELOPER_MODE' ) && DEVELOPER_MODE;
-					if ( $is_dev_mode || ( ! ezd_is_premium() && ezd_is_plugin_installed_for_days( 12 ) && ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'eazydocs-initial-setup' ) ) ) {
+					if ( $is_dev_mode || ( ! ezd_is_premium() && ezd_is_plugin_installed_for_days( 12 ) && ( ! isset( $_GET['page'] ) || 'eazydocs-initial-setup' !== $_GET['page'] ) ) ) {
 						add_action( 'admin_notices', 'ezd_offer_notice' );
 					}
 
@@ -151,7 +151,7 @@ if ( ! class_exists( 'EazyDocs' ) ) {
 				$docs_url   = ezd_get_opt( 'docs-url-structure', 'custom-slug' );
 				$permalink  = get_option( 'permalink_structure' );
 
-				if ( 'post-name' === $docs_url && ! empty( $permalink ) && $permalink !== '/archives/%post_id%' ) {
+				if ( 'post-name' === $docs_url && ! empty( $permalink ) && '/archives/%post_id%' !== $permalink ) {
 					require_once __DIR__ . '/includes/Root_Conversion.php';
 				}
 			}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2230,7 +2230,7 @@ function ezd_get_docs_tree_flat_cached( $post_type ) {
 
 	if ( false === $ordered_ids ) {
 		// Step 1: Get all top-level docs
-		$top_level_docs = get_posts( array(
+		$top_level_docs = get_posts( [
 			'post_type'   => $post_type,
 			'post_status' => 'publish',
 			'post_parent' => 0,
@@ -2238,7 +2238,7 @@ function ezd_get_docs_tree_flat_cached( $post_type ) {
 			'order'       => 'ASC',
 			'fields'      => 'ids',
 			'numberposts' => -1,
-		) );
+		] );
 
 		// Step 2: Recursively build a flat ordered list
 		$ordered_ids = [];


### PR DESCRIPTION
This PR addresses WPCS violations in `eazydocs.php` and `includes/functions.php`.

### 💡 What Changed
- **eazydocs.php**: Converted non-Yoda conditions to Yoda conditions (e.g., `$var === 'value'` → `'value' === $var`).
- **includes/functions.php**: Replaced a legacy `array()` constructor with short array syntax `[]` in `ezd_get_docs_tree_flat_cached`.

### 🎯 Why
- **Consistency**: Enforcing Yoda conditions prevents accidental assignment bugs (`if ( $a = 'b' )`).
- **Modernization**: Short array syntax `[]` is the standard since PHP 5.4 and is used throughout the rest of the codebase.
- **WPCS Compliance**: Aligns with WordPress Coding Standards.

### 📊 Impact
- **Code quality**: Improved consistency and reduced risk of bugs.
- **Behavior**: No functional changes.

### 🧪 How Tested
- [x] PHP syntax check: `php -l eazydocs.php` (Pass)
- [x] PHP syntax check: `php -l includes/functions.php` (Pass)
- [x] Manual verification: Verified logic remains identical.

### 🧩 Compatibility Notes
- PHP: Requires PHP 5.4+ (Short array syntax), which matches plugin requirement (PHP 7.4).


---
*PR created automatically by Jules for task [810350344447002759](https://jules.google.com/task/810350344447002759) started by @mdjwel*