### PR TITLE
Cache Elementor Docs Query for Frontend Performance

### DIFF
--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -89,16 +89,22 @@ class Assets
 
 		$elementor_docs = [];
 		if (class_exists('\Elementor\Plugin')) {
-			$elementor_docs = get_posts(
-				[
-					'post_type' => 'docs',
-					'post_status' => 'publish',
-					'numberposts' => -1,
-					'fields' => 'ids',
-					'meta_key' => '_elementor_edit_mode',
-					'meta_value' => 'builder',
-				]
-			);
+			$cache_key      = 'ezd_elementor_docs_ids';
+			$elementor_docs = get_transient( $cache_key );
+
+			if ( false === $elementor_docs ) {
+				$elementor_docs = get_posts(
+					[
+						'post_type'   => 'docs',
+						'post_status' => 'publish',
+						'numberposts' => - 1,
+						'fields'      => 'ids',
+						'meta_key'    => '_elementor_edit_mode',
+						'meta_value'  => 'builder',
+					]
+				);
+				set_transient( $cache_key, $elementor_docs, DAY_IN_SECONDS );
+			}
 		}
 
 		wp_localize_script(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2268,6 +2268,7 @@ function ezd_get_docs_tree_flat_cached( $post_type ) {
 function ezd_clear_docs_tree_cache( $post_id, $post ) {
 	if ( in_array( $post->post_type, [ 'docs', 'onepage-docs' ] ) ) {
 		delete_transient( 'ezd_docs_tree_flat_' . $post->post_type );
+		delete_transient( 'ezd_elementor_docs_ids' );
 	}
 }
 add_action( 'save_post', 'ezd_clear_docs_tree_cache', 10, 2 );


### PR DESCRIPTION
💡 **What:** Caches the `get_posts` query that checks for Elementor-edited docs in `includes/Frontend/Assets.php`.
🎯 **Why:** This query runs on every frontend page load with a `meta_query`, which can be slow on large sites. Caching it saves one DB query per page load.
📊 **Impact:** Reduces DB load on frontend.
🔬 **How to test:**
1.  Verify that `get_posts` is called on the first page load (cache miss).
2.  Verify that subsequent page loads use the cached transient `ezd_elementor_docs_ids` and do not trigger the query.
3.  Save or delete a doc and verify that the transient is deleted (cache invalidation).
♻️ **Backward compatible:** Yes, logic degrades gracefully if transient is missing.

---
*PR created automatically by Jules for task [8037422356340641877](https://jules.google.com/task/8037422356340641877) started by @mdjwel*